### PR TITLE
Remove 'cap' setting from Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,6 @@ steps:
         agents:
           queue: "juliagpu"
           cuda: "*"
-          cap: "sm_80"
         if: build.message !~ /\[skip tests\]/
         timeout_in_minutes: 44
         env:


### PR DESCRIPTION
Removed the 'cap' setting from the agent configuration.