### PR TITLE
Fix memory leak

### DIFF
--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+cupynumeric_jll = "2862d674-414d-5b0b-a494-b21f8deca547"
+CUDA_SDK_jll = "6cbf2f2e-7e60-5632-ac76-dca2274e0be0"
+
+[compat]
+cupynumeric_jll = "25.10"
+CUDA_SDK_jll = "13"

--- a/ext/CUDAExt/cuda.jl
+++ b/ext/CUDAExt/cuda.jl
@@ -76,7 +76,7 @@ end
 
 function nda_to_logical_array(arr::NDArray{T,N}) where {T,N}
     st_handle = cuNumeric.get_store(arr)
-    return Legate.LogicalArray{T,N}(st_handle[], size(arr))
+    return Legate.LogicalArray{T,N}(st_handle, size(arr))
 end
 
 function Launch(kernel::cuNumeric.CUDATask, inputs::Tuple{Vararg{NDArray}},

--- a/lib/cunumeric_jl_wrapper/src/wrapper.cpp
+++ b/lib/cunumeric_jl_wrapper/src/wrapper.cpp
@@ -42,10 +42,7 @@ struct WrapCppOptional {
   }
 };
 
-legate::LogicalArray* get_store(CN_NDArray* arr) {
-  auto res = arr->obj.get_store();
-  return new legate::LogicalArray(std::move(res));
-}
+legate::LogicalArray get_store(CN_NDArray* arr) { return arr->obj.get_store(); }
 
 legate::Library get_lib() {
   auto runtime = cupynumeric::CuPyNumericRuntime::get_runtime();

--- a/src/ndarray/detail/ndarray.jl
+++ b/src/ndarray/detail/ndarray.jl
@@ -62,7 +62,7 @@ mutable struct NDArray{T,N,PADDED,P} <: AbstractNDArray{T,N}
         return handle
     end
 end
-# this here is to avoid if else patterns 
+# this here is to avoid if else patterns
 @inline _NDArray(ptr, T, v, ::Nothing) = NDArray(ptr, T, v)
 @inline _NDArray(ptr, T, v, parent) = NDArray(ptr, T, v, parent)
 
@@ -219,7 +219,9 @@ function nda_unary_reduction(out::NDArray, op_code::UnaryRedCode, input::NDArray
     return out
 end
 
-function nda_unary_reduction_axes(op_code::UnaryRedCode, input::NDArray{T,N}, axes::Vector{Int32}, keepdims::Bool) where {T,N}
+function nda_unary_reduction_axes(
+    op_code::UnaryRedCode, input::NDArray{T,N}, axes::Vector{Int32}, keepdims::Bool
+) where {T,N}
     axes_c = collect(Int32, axes)
     ptr = ccall((:nda_unary_reduction_axes, libnda),
         NDArray_t, (UnaryRedCode, NDArray_t, Ptr{Int32}, Int32, Cint),
@@ -336,11 +338,8 @@ function get_store(arr::NDArray)
 end
 
 function get_ptr(arr::NDArray{T,N}) where {T,N}
-    # Get the raw Legate array impl
-    st_handle = get_store(arr) # CxxPtr{LogicalArrayImpl}
-    # Wrap it in the high-level LogicalArray struct expected by Legate.get_ptr
-    # st_handle[] dereferences the CxxPtr to get the LogicalArrayImpl object
-    la = Legate.LogicalArray{T,N}(st_handle[], size(arr))
+    st_handle = get_store(arr) # LogicalArrayImplAllocated (returned by value)
+    la = Legate.LogicalArray{T,N}(st_handle, size(arr))
     return Legate.get_ptr(la)
 end
 


### PR DESCRIPTION
Using std::move to change ownership breaks CxxWrap's referencing of the store object. 

We need to return by value for CxxWrap to destruct the right object properly. 