### PR TITLE
skip Int8 unary reduction (with dims) tests on minimum and maximum on…

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,6 +187,11 @@ end
                 continue
             end
 
+            ## TODO Int8 min/max along an axis is broken on GPU
+            if cuNumeric.HAS_CUDA && T == Int8 && (func == Base.minimum || func == Base.maximum)
+                continue
+            end
+
             test_unary_reduction_dims(func, julia_arr_1D, cunumeric_arr_1D)
             test_unary_reduction_dims(func, julia_arr_2D, cunumeric_arr_2D)
         end


### PR DESCRIPTION
```python
import numpy as onp
import cupynumeric as np

host = onp.random.randint(-128, 128, size=(256, 256), dtype=onp.int8)
a = np.array(host)
got = onp.asarray(a.min(axis=0))
ref = host.min(axis=0)
print("mismatches:", int((got != ref).sum()))
```

This code in python fails with a GPU. We are seeing the same issue in Julia. This only occurs on GPU & T=Int8 on unary reductions w/ dims. Unary reductions without axis/dims works fine on GPU.