### PR TITLE
Remove complex type mappings for Julia

### DIFF
--- a/lib/cunumeric_jl_wrapper/src/wrapper.cpp
+++ b/lib/cunumeric_jl_wrapper/src/wrapper.cpp
@@ -74,9 +74,6 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
   using jlcxx::TypeVar;
   using legate_util::HalfType;
 
-  // Map C++ complex types to Julia complex types
-  mod.map_type<std::complex<double>>("ComplexF64");
-  mod.map_type<std::complex<float>>("ComplexF32");
   mod.map_type<HalfType>("Float16");
 
   // These are the types/dims used to generate templated functions

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -100,6 +100,5 @@ function maybe_collect()
         recalibrate_allocator!()
     end
 
-    
     return nothing
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -100,5 +100,6 @@ function maybe_collect()
         recalibrate_allocator!()
     end
 
+    
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,18 @@ include("tests/binary_tests.jl")
 include("tests/scoping.jl")
 include("tests/scoping-advanced.jl")
 
+@testset "Array Accessors" begin
+    for T in Base.uniontypes(cuNumeric.SUPPORTED_ARRAY_TYPES)
+        value = rand(T)
+        arr = cuNumeric.zeros(T, 2, 2)
+
+        allowscalar() do
+            arr[1, 2] = value
+            @test arr[1, 2] == value
+        end
+    end
+end
+
 @testset verbose = true "AXPY" begin
     N = 100
     @testset verbose = true for T in Base.uniontypes(cuNumeric.SUPPORTED_FLOAT_TYPES)


### PR DESCRIPTION
requires legate_branch:  ci-test

These seem to be defined in libcxxwrap_julia and we get this warning:

```
Warning: Type St7complexIdE already had a mapped type set as Complex
Warning: Type St7complexIfE already had a mapped type set as Complex
```