### PR TITLE
Diag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,8 +26,8 @@ libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 
 [compat]
 CNPreferences = "0.1.2"
-CUDACore = "6.0.0"
-CUDATools = "6.0.0"
+CUDACore = "6"
+CUDATools = "6"
 CxxWrap = "0.17"
 ExpressionExplorer = "1.1.4"
 JuliaFormatter = "2.3.0"

--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@ For more details, see [Hardware](./configuration/hardware.md).
 
 The semantics of `NDArray` closely mirror Julia's `Array`, and in most cases it is a drop-in replacement. You can use the same constructors (i.e., `zeros`, `ones`, `rand`), broadcasting, slicing, and linear algebra. Under the hood a few details differ from Base, and knowing them can help you write fast code.
 
-**Data may live across many devices.** An `NDArray` is a logical array whose physical buffers can be partitioned over GPUs and CPUs by the Legate runtime. You write ordinary array code and Legate decides where the data lives and how/when it is communicated between devices. As a result, elementwise indexing (i.e. `arr[1]`) is slow (and is prevented by default). Scalar indexing like this forces synchronization and blocks other tasks from executing.
+**Data may live across many devices.** An `NDArray` is a logical array whose physical buffers can be partitioned over GPUs and CPUs by the Legate runtime. You write ordinary array code and Legate decides where the data lives and how/when it is communicated between devices. As a result, elementwise indexing (i.e. `arr[1]`) is slow (and is prevented by default). Scalar indexing like this forces synchronization and blocks other tasks from executing. Functions like `println` result in data being copied to the host and can also be slow.
 
 **Slices are views.** Indexing an `NDArray` with ranges returns a view onto the same store, not a copy. That differs from Base Julia, where `A[1:n]` allocates a new `Array`. Mutations through an `NDArray` slice are visible through other aliases of the same data.
 
-**Reductions return arrays, not Julia scalars.** Reductions such as `sum(A)` produce a **0D or 1D** `NDArray` (axis reductions produce a lower-rank `NDArray`), rather than a bare `Float64` / `Float32`. That keeps the Legate task graph asynchronous instead of forcing synchronization to communite with the Julia runtime. When you need a plain Julia number, call `unwrap`:
+**Reductions return arrays, not Julia scalars.** Reductions such as `sum(A)` produce a **0D or 1D** `NDArray` (axis reductions produce a lower-rank `NDArray`), rather than a bare `Float64` / `Float32`. That keeps the Legate task graph asynchronous instead of forcing synchronization to communite with the Julia runtime. When you need a plain Julia number, call `unwrap` or `only`:
 
 ```julia
 s = sum(A)          # NDArray{T,0}
 x = unwrap(s)       # T, e.g. Float32
+x2 = only(s)
 ```
 
 **The Legate runtime builds a DAG asynchronously.** Calling `cuNumeric.zeros` or `A .+ B` records work into Legate's task graph rather than blocking until every GPU kernel finishes. Results are materialized when you need them (for example `println`, `unwrap`, or converting with `Array(A)`). Hiding latency enables performant code.

--- a/lib/cunumeric_jl_wrapper/src/cuda.cpp
+++ b/lib/cunumeric_jl_wrapper/src/cuda.cpp
@@ -367,9 +367,8 @@ static inline void align8(char *&ptr) {
 //   [9..8+N] = arg_map entries (Int32 each)
 //   [9+N..]  = actual scalar values
 //
-// Host passes an occupancy thread *budget* in tx (ty/tz unused) and a
-// placeholder bx. This task overwrites bx/tx from the local output tile
-// (linear: threads=min(budget,volume), blocks=cld(volume,threads)).
+// Host passes an occupancy thread budget in tx and a placeholder bx. This task
+// derives the launch geometry from the local output tile.
 //
 // arg_map encoding:
 //   val >= 0, val < num_outputs  → output[val] (write CuStridedDeviceArray)
@@ -382,13 +381,29 @@ static void broadcast_launch_dims_from_tile(PTXLaunchParams &lp,
   const std::uint32_t budget = std::max(lp.tx, 1u);
   const int dim = out.dim();
 
-  if (dim <= 0) {
-    lp.bx = 1;
-    lp.by = 1;
-    lp.bz = 1;
-    lp.tx = 1;
-    lp.ty = 1;
+  assert(dim > 0);
+
+  if (dim == 2) {
+    const auto shape = out.shape<2>();
+    const auto extents = shape.hi - shape.lo + legate::Point<2>::ONES();
+    const std::uint64_t rows = extents[0];
+    const std::uint64_t cols = extents[1];
+
+    assert(rows > 0 && cols > 0);
+
+    lp.tx = static_cast<std::uint32_t>(std::min<std::uint64_t>(budget, cols));
+    lp.ty = static_cast<std::uint32_t>(
+        std::min<std::uint64_t>(budget / lp.tx, rows));
     lp.tz = 1;
+    lp.bx = static_cast<std::uint32_t>((cols + lp.tx - 1) / lp.tx);
+    lp.by = static_cast<std::uint32_t>((rows + lp.ty - 1) / lp.ty);
+    lp.bz = 1;
+
+#ifdef CUDA_DEBUG
+    std::cerr << "[RunPTXBroadcastTask] local shape=" << rows << "x" << cols
+              << " -> blocks=(" << lp.bx << "," << lp.by << ") threads=("
+              << lp.tx << "," << lp.ty << ") budget=" << budget << std::endl;
+#endif
     return;
   }
 
@@ -402,9 +417,6 @@ static void broadcast_launch_dims_from_tile(PTXLaunchParams &lp,
   switch (dim) {
     case 1:
       CU_BCAST_FILL_VOLUME(1);
-      break;
-    case 2:
-      CU_BCAST_FILL_VOLUME(2);
       break;
     case 3:
       CU_BCAST_FILL_VOLUME(3);
@@ -424,15 +436,7 @@ static void broadcast_launch_dims_from_tile(PTXLaunchParams &lp,
   }
 #undef CU_BCAST_FILL_VOLUME
 
-  if (volume == 0) {
-    lp.bx = 1;
-    lp.by = 1;
-    lp.bz = 1;
-    lp.tx = 1;
-    lp.ty = 1;
-    lp.tz = 1;
-    return;
-  }
+  assert(volume > 0);
 
   const std::uint32_t threads =
       static_cast<std::uint32_t>(std::min<std::uint64_t>(budget, volume));

--- a/src/cuNumeric.jl
+++ b/src/cuNumeric.jl
@@ -166,6 +166,7 @@ const FUSE_BROADCAST_EXPRS = CNPreferences.FUSE_BROADCAST
 const FUSE_BROADCAST_MIN_OPS = CNPreferences.FUSE_BROADCAST_MIN_OPS
 
 # Functionality
+include("ndarray/diagonal.jl")
 include("ndarray/promotion.jl")
 include("cuda/cuda_ptx_task.jl")
 include("ndarray/broadcast_fusion.jl")

--- a/src/cuda/strided_device_array.jl
+++ b/src/cuda/strided_device_array.jl
@@ -33,7 +33,7 @@ Base.elsize(::Type{<:CuStridedDeviceArray{T}}) where {T} = sizeof(T)
 Base.size(a::CuStridedDeviceArray) = a.dims
 Base.size(a::CuStridedDeviceArray{<:Any,1}) = (a.len,)
 Base.length(a::CuStridedDeviceArray) = a.len
-Base.IndexStyle(::Type{<:CuStridedDeviceArray}) = IndexLinear()
+Base.IndexStyle(::Type{<:CuStridedDeviceArray}) = IndexCartesian()
 
 function Base.pointer(a::CuStridedDeviceArray{T,<:Any,A}) where {T,A}
     return Base.unsafe_convert(CUDACore.LLVMPtr{T,A}, a)
@@ -72,6 +72,11 @@ end
     return off
 end
 
+@inline function _strided_elem_offset(strides::Dims{2}, I::CartesianIndex{2})
+    @inbounds return (Int(I[1]) - 1) * Int(strides[1]) +
+                     (Int(I[2]) - 1) * Int(strides[2])
+end
+
 @inline _strided_align(::CuStridedDeviceArray{T}) where {T} = Base.datatype_alignment(T)
 
 # No @boundscheck / throw — those emit gpu_report_exception and break LoadPTX.
@@ -86,6 +91,21 @@ CUDACore.@device_function @inline function _strided_arrayset(
     A::CuStridedDeviceArray{T}, x::T, index::Integer
 ) where {T}
     off = _strided_elem_offset(A.dims, A.strides, index)
+    unsafe_store!(pointer(A), x, off + 1, Val(_strided_align(A)))
+    return A
+end
+
+CUDACore.@device_function @inline function _strided_arrayref(
+    A::CuStridedDeviceArray{T,N}, I::CartesianIndex{N}
+) where {T,N}
+    off = _strided_elem_offset(A.strides, I)
+    return unsafe_load(pointer(A), off + 1, Val(_strided_align(A)))
+end
+
+CUDACore.@device_function @inline function _strided_arrayset(
+    A::CuStridedDeviceArray{T,N}, x::T, I::CartesianIndex{N}
+) where {T,N}
+    off = _strided_elem_offset(A.strides, I)
     unsafe_store!(pointer(A), x, off + 1, Val(_strided_align(A)))
     return A
 end
@@ -105,14 +125,23 @@ Base.to_index(::CuStridedDeviceArray, i::Integer) = i
 Base.@propagate_inbounds function Base.getindex(
     A::CuStridedDeviceArray{T,N}, I::CartesianIndex{N}
 ) where {T,N}
-    off = _strided_elem_offset(A.strides, I)
-    return unsafe_load(pointer(A), off + 1, Val(_strided_align(A)))
+    return _strided_arrayref(A, I)
 end
 
 Base.@propagate_inbounds function Base.setindex!(
     A::CuStridedDeviceArray{T,N}, x, I::CartesianIndex{N}
 ) where {T,N}
-    off = _strided_elem_offset(A.strides, I)
-    unsafe_store!(pointer(A), convert(T, x)::T, off + 1, Val(_strided_align(A)))
-    return A
+    return _strided_arrayset(A, convert(T, x)::T, I)
+end
+
+Base.@propagate_inbounds function Base.getindex(
+    A::CuStridedDeviceArray{T,N}, I::Vararg{Integer,N}
+) where {T,N}
+    return _strided_arrayref(A, CartesianIndex(I))
+end
+
+Base.@propagate_inbounds function Base.setindex!(
+    A::CuStridedDeviceArray{T,N}, x, I::Vararg{Integer,N}
+) where {T,N}
+    return _strided_arrayset(A, convert(T, x)::T, CartesianIndex(I))
 end

--- a/src/ndarray/binary.jl
+++ b/src/ndarray/binary.jl
@@ -136,8 +136,10 @@ function Base.:(+)(rhs1::NDArray{A,N}, rhs2::NDArray{B,N}) where {A,B,N}
     return _nda_binary_op_promoted!(out, cuNumeric.ADD, rhs1, rhs2)
 end
 
-Base.:(*)(val::V, arr::NDArray{A}) where {A,V} = _mul_scalar(__my_promote_type(A, V), val, arr)
-Base.:(*)(arr::NDArray{A}, val::V) where {A,V} = val * arr
+function Base.:(*)(val::V, arr::NDArray{A}) where {A,V<:Number}
+    _mul_scalar(__my_promote_type(A, V), val, arr)
+end
+Base.:(*)(arr::NDArray{A}, val::V) where {A,V<:Number} = val * arr
 
 _mul_scalar(::Type{T}, val, arr::NDArray{T}) where {T} = nda_multiply_scalar(arr, T(val))
 function _mul_scalar(::Type{U}, val, arr::NDArray) where {U}

--- a/src/ndarray/broadcast.jl
+++ b/src/ndarray/broadcast.jl
@@ -196,7 +196,7 @@ end
     # Fused writes `dest` in place (no post-fuse `nda_move`); promotion is
     # checked pre-launch in `fuse_broadcast_tree!`. CPU vs GPU is compile-time
     # via `@static if FUSE_BROADCAST_EXPRS && HAS_CUDA`.
-    # Linear-only fusion requires same-shaped NDArray leaves; otherwise fall back.
+    # Fusion requires same-shaped NDArray leaves; otherwise fall back.
     # Single-op exprs (length < `FUSE_BROADCAST_MIN_OPS`) stay unfused by default.
     @static if FUSE_BROADCAST_EXPRS && HAS_CUDA
         if _should_attempt_broadcast_fusion(dest, bc)

--- a/src/ndarray/broadcast_fusion.jl
+++ b/src/ndarray/broadcast_fusion.jl
@@ -8,11 +8,9 @@ end
 
 Base.@propagate_inbounds _gpu_broadcast_getindex(x::Number, I) = x
 
-# Bypass Broadcast.newindex: for N-D arrays, `_broadcast_getindex(A, I::Int)` becomes
-# `A[CartesianIndex(I, 1, 1, ...)]`, which is wrong for our linear work ids.
-# Dest already uses linear `dest[I]`; reads must use the same strided linear path.
+# Same-shaped fused operands already use the destination index.
 Base.@propagate_inbounds @inline function _gpu_broadcast_getindex(
-    x::CuStridedDeviceArray, I::Integer
+    x::CuStridedDeviceArray, I::Union{Integer,CartesianIndex}
 )
     return @inbounds x[I]
 end
@@ -145,6 +143,44 @@ function make_linear_kernel(dest, bc::Base.Broadcast.Broadcasted, arg_plan, stat
     return broadcast_kernel_linear_splat
 end
 
+@inline function _broadcast_cartesian_work_id()
+    row =
+        (Int(CUDACore.blockIdx().y) - 1) * Int(CUDACore.blockDim().y) +
+        Int(CUDACore.threadIdx().y)
+    col =
+        (Int(CUDACore.blockIdx().x) - 1) * Int(CUDACore.blockDim().x) +
+        Int(CUDACore.threadIdx().x)
+    return CartesianIndex(row, col)
+end
+
+function make_cartesian_kernel(dest, bc::Base.Broadcast.Broadcasted, arg_plan, static_args)
+    f = bc.f
+
+    @kernel unsafe_indices = true function broadcast_kernel_cartesian_splat(
+        dest, runtime_args...
+    )
+        I = _broadcast_cartesian_work_id()
+        if I[1] <= size(dest, 1) && I[2] <= size(dest, 2)
+            @inbounds args_modified = _materialize_broadcast_args(
+                arg_plan, runtime_args, static_args, I
+            )
+            @inbounds dest[I] = Base.Broadcast._broadcast_getindex_evalf(f, args_modified...)
+        end
+    end
+
+    return broadcast_kernel_cartesian_splat
+end
+
+function make_broadcast_kernel(
+    dest::NDArray{<:Any,2}, bc::Base.Broadcast.Broadcasted, arg_plan, static_args
+)
+    return make_cartesian_kernel(dest, bc, arg_plan, static_args)
+end
+
+function make_broadcast_kernel(dest, bc::Base.Broadcast.Broadcasted, arg_plan, static_args)
+    return make_linear_kernel(dest, bc, arg_plan, static_args)
+end
+
 struct FusedBroadcastMetadata
     ctx::Any # KA.CompilerMetadata (compilation / arg layout; not global ndrange)
     threads::Int # occupancy thread budget; device chooses final launch dims
@@ -156,12 +192,10 @@ end
 const _BCAST_PTX_CACHE = Dict{Tuple{Any,DataType,DataType},FusedBroadcastMetadata}()
 const _BCAST_PTX_CACHE_LOCK = ReentrantLock()
 
-# Linear-only fusion: every NDArray leaf must match `dest` shape. Shape-mismatched
-# broadcasts (e.g. matrix .+ vector) need cartesian / Extruded indexing and are
-# handled by the unfused path instead.
+# Every NDArray leaf must match `dest` shape. Shape-mismatched broadcasts
+# (e.g. matrix .+ vector) are handled by the unfused path.
 #
-# Slice views are allowed: RunPTXBroadcastTask packs element strides so linear
-# `I` indexes through CuStridedDeviceArray correctly.
+# Slice views are allowed: RunPTXBroadcastTask packs their element strides.
 @inline _can_fuse_linear_broadcast_leaf(dest, ::Number) = true
 @inline _can_fuse_linear_broadcast_leaf(dest, ::Base.RefValue) = true
 @inline function _can_fuse_linear_broadcast_leaf(dest, x::NDArray)
@@ -182,7 +216,7 @@ end
 end
 
 """
-Return true when fused linear broadcast is safe for `bc` into `dest`.
+Return true when same-shaped broadcast fusion is safe for `bc` into `dest`.
 
 Requires every NDArray leaf to have the same size as `dest`. Scalars / RefValues
 are allowed. Unknown leaf types refuse fusion (fall back to unfused).
@@ -196,22 +230,20 @@ Also refuses 0-d destinations: `RunPTXBroadcastTask` only supports dims in
     return _can_fuse_linear_broadcast_leaf(dest, bc)
 end
 
-# After Broadcast.preprocess, same-shape arrays are wrapped in Extruded with all
-# keeps=true. Unwrap those so the kernel indexes CuStridedDeviceArray with linear `I`
-# (avoids Extruded/CartesianIndices paths that emit gpu_report_exception in PTX).
-@inline function _unwrap_linear_fusion_arg(x::Base.Broadcast.Extruded)
+# Same-shaped operands do not need Broadcast's dynamic index projection.
+@inline function _unwrap_fusion_arg(x::Base.Broadcast.Extruded)
     if all(x.keeps)
         return x.x
     end
     throw(
         ArgumentError(
-            "Broadcast fusion (linear-only) does not support shape-mismatched " *
+            "Broadcast fusion does not support shape-mismatched " *
             "Extruded arguments; use the unfused broadcast path",
         ),
     )
 end
-@inline _unwrap_linear_fusion_arg(x) = x
-@inline _unwrap_linear_fusion_args(args::Tuple) = _unwrap_linear_fusion_arg.(args)
+@inline _unwrap_fusion_arg(x) = x
+@inline _unwrap_fusion_args(args::Tuple) = _unwrap_fusion_arg.(args)
 
 # Host-side scalar alignment for fusion — same as unfused
 # `T_IN = __my_promote_type(...); unchecked_promote_arr.(args, T_IN)`, but
@@ -330,7 +362,7 @@ function get_ptx(
     # dump_module=true keeps only_entry=false so linked libdevice helpers (e.g. cos
     # slowpaths) are not emptied into unresolved .externs before cuModuleLoad.
     CUDATools.code_ptx(buf, obj.f, (typeof(ctx), DEST_T, arg_types...);
-        raw=false, dump_module=true, kernel=true)
+        raw=false, dump_module=true, kernel=true, ptx=v"7.8")
 
     return String(take!(buf)), threads, ctx
 end
@@ -458,9 +490,10 @@ function _describe_fused_broadcast(
     isempty(actual_scalars) || field("scalars", join(repr.(actual_scalars), ", "))
     isempty(static_args) || field("static", join(repr.(static_args), ", "))
     field("arg_map", "$(Int.(arg_map))  (0=output, >=1=input idx+1, <0=scalar)")
+    indexing = ndims(dest) == 2 ? "cartesian" : "linear"
     field(
         "launch",
-        "host thread budget=$(fkm.threads), indexing=linear, " *
+        "host thread budget=$(fkm.threads), indexing=$indexing, " *
         "blocks=device(local tile), global_ndrange=$ndrange",
     )
     field(
@@ -548,13 +581,13 @@ function fuse_broadcast_tree!(dest::D, bc::B) where {D<:NDArray,B<:Base.Broadcas
     # not is-bits types. We split these out manually into static args and handle
     # them separately from runtime args (i.e., arrays, scalars)
     runtime_args, static_args, arg_plan = split_broadcast_args_for_kernel(
-        _unwrap_linear_fusion_args(bc.args)
+        _unwrap_fusion_args(bc.args)
     )
     # Host-only, before PTX cache: same `__my_promote_type` + Number convert as
     # unfused `T_IN` / `unchecked_promote_arr`. Kernel sees already-aligned types.
     runtime_args = _align_fused_runtime_args(runtime_args)
 
-    broadcast_kernel = make_linear_kernel(dest, bc, arg_plan, static_args)
+    broadcast_kernel = make_broadcast_kernel(dest, bc, arg_plan, static_args)
 
     ndrange = ndims(dest) > 0 ? size(dest) : (1,)
 

--- a/src/ndarray/detail/ndarray.jl
+++ b/src/ndarray/detail/ndarray.jl
@@ -35,7 +35,7 @@ end
 
 get_n_dim(ptr::NDArray_t) = Int(ccall((:nda_array_dim, libnda), Int32, (NDArray_t,), ptr))
 
-abstract type AbstractNDArray{T<:SUPPORTED_TYPES,N} end
+abstract type AbstractNDArray{T<:SUPPORTED_TYPES,N} <: AbstractArray{T,N} end
 
 @doc"""
 The NDArray type represents a multi-dimensional array in cuNumeric.

--- a/src/ndarray/diagonal.jl
+++ b/src/ndarray/diagonal.jl
@@ -1,0 +1,133 @@
+@doc"""
+    cuNumeric.diag(arr::NDArray; k=0)
+
+Extract the k-th diagonal from a 2D `NDArray`.
+"""
+function diag(arr::NDArray; k::Int=0)
+    return nda_diag(arr, Int32(k))
+end
+
+@doc"""
+    cuNumeric._eye([T=Float32,] rows::Int)
+
+Create a 2D identity `NDArray` of size `rows × rows` with element type `T`.
+The default type is Float32 if not specified. Prefer LinearAlgebra.I instead
+    or `LinearAlgebra.Diagonal`
+"""
+function _eye(::Type{T}, rows::Int) where {T}
+    return nda_eye(Int32(rows), T)
+end
+function _eye(rows::Int)
+    return eye(DEFAULT_FLOAT, rows)
+end
+
+@doc"""
+    cuNumeric.trace(arr::NDArray; offset=0, a1=0, a2=1)
+
+Compute the trace (sum of a diagonal) of the `NDArray`.
+The accumulator type follows promotions of other reductions like 'sum'.
+"""
+function trace(arr::NDArray{T}; offset::Int=0, a1::Int=0, a2::Int=1) where {T}
+    T_OUT = Base.promote_op(Base.sum, Vector{T})
+    return nda_trace(arr, Int32(offset), Int32(a1), Int32(a2), T_OUT)
+end
+
+# Prefer the cuNumeric backend over LinearAlgebra.diag's scalar-indexing fallback
+# now that NDArray <: AbstractArray.
+LinearAlgebra.diag(arr::NDArray{<:Any,2}, k::Integer=0) = nda_diag(arr, Int32(k))
+
+# Wrap without copying. Must call the typed inner constructor — `Diagonal(arr)`
+# would recurse into this method instead of LinearAlgebra's AbstractVector method.
+function LinearAlgebra.Diagonal(arr::NDArray{T,1}) where {T}
+    return Diagonal{T,typeof(arr)}(arr)
+end
+
+function LinearAlgebra.Diagonal(arr::NDArray{T,2}) where {T}
+    return Diagonal(diag(arr))
+end
+
+function Base.show(
+    io::IO,
+    D::LinearAlgebra.Diagonal{T,V},
+) where {T,V<:NDArray{T,1}}
+    host_D = LinearAlgebra.Diagonal(Array(D.diag))
+    return show(io, host_D)
+end
+
+function Base.show(
+    io::IO,
+    ::MIME"text/plain",
+    D::LinearAlgebra.Diagonal{T,V},
+) where {T,V<:NDArray{T,1}}
+    summary(io, D)
+    isempty(D) && return nothing
+
+    println(io, ":")
+    host_D = LinearAlgebra.Diagonal(Array(D.diag))
+    return Base.print_array(io, host_D)
+end
+
+#### UniformScaling (LinearAlgebra.I) ####
+
+# Dense λI with element type R. Avoids LinearAlgebra's scalar-indexing fallbacks.
+@inline function _uniformscaling_eye(::Type{R}, n::Integer, λ) where {R}
+    E = _eye(R, Int(n))
+    return isone(λ) ? E : nda_multiply_scalar(E, R(λ))
+end
+
+# Like CuArray(I, n, n) / CuArray{T}(I, dims)
+function NDArray{T}(J::LinearAlgebra.UniformScaling, dims::Dims{2}) where {T}
+    A = zeros(T, dims)
+    copyto!(A, J)
+    return A
+end
+function NDArray{T}(J::LinearAlgebra.UniformScaling, m::Integer, n::Integer) where {T}
+    NDArray{T}(J, Dims((Int(m), Int(n))))
+end
+NDArray(J::LinearAlgebra.UniformScaling{T}, dims::Dims{2}) where {T} = NDArray{T}(J, dims)
+function NDArray(J::LinearAlgebra.UniformScaling{T}, m::Integer, n::Integer) where {T}
+    NDArray{T}(J, Dims((Int(m), Int(n))))
+end
+
+function Base.copyto!(A::NDArray{T,2}, J::LinearAlgebra.UniformScaling) where {T}
+    m, n = size(A)
+    if iszero(J.λ)
+        return fill!(A, zero(T))
+    elseif m == n
+        return copyto!(A, _uniformscaling_eye(T, m, J.λ))
+    else
+        fill!(A, zero(T))
+        k = min(m, n)
+        A[1:k, 1:k] = _uniformscaling_eye(T, k, J.λ)
+        return A
+    end
+end
+
+function Base.:+(A::NDArray{T,2}, J::LinearAlgebra.UniformScaling) where {T}
+    LinearAlgebra.checksquare(A)
+    R = Base.promote_op(+, T, typeof(J.λ))
+    return A + _uniformscaling_eye(R, size(A, 1), J.λ)
+end
+Base.:+(J::LinearAlgebra.UniformScaling, A::NDArray{<:Any,2}) = A + J
+
+Base.:-(A::NDArray{<:Any,2}, J::LinearAlgebra.UniformScaling) = A + (-J)
+function Base.:-(J::LinearAlgebra.UniformScaling, A::NDArray{<:Any,2})
+    return (-A) + J
+end
+
+# Scale by λ without promoting the array (A * I must not Bool→Float32 promote).
+function Base.:*(A::NDArray{T}, J::LinearAlgebra.UniformScaling) where {T}
+    return _mul_scalar(T, J.λ, A)
+end
+function Base.:*(J::LinearAlgebra.UniformScaling, A::NDArray{T}) where {T}
+    return _mul_scalar(T, J.λ, A)
+end
+
+function Base.one(A::NDArray{T,2}) where {T}
+    LinearAlgebra.checksquare(A)
+    return eye(T, size(A, 1))
+end
+function Base.oneunit(A::NDArray{T,2}) where {T}
+    LinearAlgebra.checksquare(A)
+    return eye(T, size(A, 1))
+end

--- a/src/ndarray/ndarray.jl
+++ b/src/ndarray/ndarray.jl
@@ -30,39 +30,6 @@ function transpose(arr::NDArray)
 end
 
 @doc"""
-    cuNumeric.eye([T=Float32,] rows::Int)
-
-Create a 2D identity `NDArray` of size `rows × rows` with element type `T`.
-The default type is Float32 if not specified.
-"""
-function eye(::Type{T}, rows::Int) where {T}
-    return nda_eye(Int32(rows), T)
-end
-function eye(rows::Int)
-    return eye(DEFAULT_FLOAT, rows)
-end
-
-@doc"""
-    cuNumeric.trace(arr::NDArray; offset=0, a1=0, a2=1)
-
-Compute the trace (sum of a diagonal) of the `NDArray`.
-The accumulator type follows promotions of other reductions like 'sum'.
-"""
-function trace(arr::NDArray{T}; offset::Int=0, a1::Int=0, a2::Int=1) where {T}
-    T_OUT = Base.promote_op(Base.sum, Vector{T})
-    return nda_trace(arr, Int32(offset), Int32(a1), Int32(a2), T_OUT)
-end
-
-@doc"""
-    cuNumeric.diag(arr::NDArray; k=0)
-
-Extract the k-th diagonal from a 2D `NDArray`.
-"""
-function diag(arr::NDArray; k::Int=0)
-    return nda_diag(arr, Int32(k))
-end
-
-@doc"""
     cuNumeric.ravel(arr::NDArray)
 
 Return a flattened 1D view of the input `NDArray`.
@@ -111,7 +78,10 @@ copyto!(a, b);
 a[1,1]
 ```
 """
-Base.copyto!(arr::NDArray{T,N}, other::NDArray{T,N}) where {T,N} = nda_assign(arr, other)
+@inline function Base.copyto!(arr::NDArray{T,N}, other::NDArray{T,N}) where {T,N}
+    nda_assign(arr, other)
+    return arr
+end
 
 @doc"""
     as_type(arr::NDArray, t::Type{T}) where {T}
@@ -143,31 +113,34 @@ end
 # get_ptr is a blocking call that grabs the physical store
 # we have not tested across multiple processes or devices yet
 
-function (::Type{<:Array{A}})(arr::NDArray{B,0}) where {A,B}
-    out = Array{A}(undef)
+function Base.Array{A}(arr::NDArray{B,0}) where {A,B}
+    out = Array{A,0}(undef)
     allowscalar() do
-        return out[] = convert(A, arr[])
+        out[] = convert(A, arr[])
     end
     return out
 end
 
-function (::Type{<:Array{A}})(arr::NDArray{B,1}) where {A,B}
-    return make_array(A, Ptr{A}(get_ptr(arr)), size(arr))
+function Base.Array{A}(arr::NDArray{B,1}) where {A,B}
+    host = make_array(B, Ptr{B}(get_ptr(arr)), size(arr))
+    return A === B ? host : A.(host)
 end
 
 # TODO: query the store's DimOrdering instead of assuming row-major (C-order).
 # Julia Arrays are column-major, so for C-ordered buffers we transpose, wrap,
 # then transpose back so `Array(nda)` matches `nda[i,j]`.
-function (::Type{<:Array{A}})(arr::NDArray{B}) where {A,B}
+function Base.Array{A}(arr::NDArray{B,N}) where {A,B,N}
     t = transpose(arr)
     w = make_array(B, Ptr{B}(get_ptr(t)), size(t))
     out = collect(permutedims(w, reverse(1:ndims(w))))
-    return A === B ? out : copyto!(Array{A}(undef, size(arr)), out)
+
+    return A === B ? out :
+           copyto!(Array{A}(undef, size(arr)), out)
 end
 
-function (::Type{<:Array})(arr::NDArray{B}) where {B}
-    return Array{B}(arr)
-end
+Base.Array(arr::NDArray{B,N}) where {B,N} = Array{B}(arr)
+
+Base.Array{A,N}(arr::NDArray{B,N}) where {A,B,N} = Array{A}(arr)
 
 # conversion from Base Julia array to NDArray
 # Julia Arrays are column-major; Legate stores are row-major. For N>=2 we
@@ -235,7 +208,7 @@ dim(::NDArray{T,N}) where {T,N} = N::Int
 Base.ndims(::NDArray{T,N}) where {T,N} = N::Int
 @doc"""
     Base.size(arr::NDArray)
-    Base.size(arr::NDArray, dim::Int)
+    Base.size(arr::NDArray, dim::Integer)
 
 Return the size of the given `NDArray`.
 
@@ -250,12 +223,13 @@ size(arr, 2)
 ```
 """
 Base.size(arr::NDArray{<:Any,N}) where {N} = cuNumeric.shape(arr)
-Base.size(arr::NDArray, dim::Int) = Base.size(arr)[dim]
+Base.size(arr::NDArray, dim::Integer) = dim <= ndims(arr) ? size(arr)[dim] : 1
 Base.isempty(arr::NDArray) = any(==(0), size(arr))
+Base.length(arr::NDArray) = prod(size(arr))
 
 @doc"""
-    Base.firstindex(arr::NDArray, dim::Int)
-    Base.lastindex(arr::NDArray, dim::Int)
+    Base.firstindex(arr::NDArray, dim::Integer)
+    Base.lastindex(arr::NDArray, dim::Integer)
     Base.lastindex(arr::NDArray)
 
 Provide the first and last valid indices along a given dimension `dim` for `NDArray`.
@@ -268,44 +242,32 @@ lastindex(arr, 2)
 lastindex(arr)
 ```
 """
-Base.firstindex(arr::NDArray, dim::Int) = 1
-Base.lastindex(arr::NDArray, dim::Int) = Base.size(arr, dim)
-Base.lastindex(arr::NDArray) = Base.size(arr, 1)
+Base.firstindex(arr::NDArray, dim::Integer) = 1
+Base.lastindex(arr::NDArray, dim::Integer) = size(arr, dim)
+Base.lastindex(arr::NDArray) = length(arr)
 
 Base.axes(arr::NDArray) = Base.OneTo.(size(arr))
 Base.view(arr::NDArray, inds...) = arr[inds...] # NDArray slices are views by default.
 
-Base.IndexStyle(::NDArray) = IndexCartesian()
-
 function Base.show(io::IO, arr::NDArray{T,0}) where {T}
-    allowscalar() do
-        return print(io, "NDArray{$(T),0}(", repr(arr[]), ")")
-    end
+    print(io, summary(arr), "(")
+    @allowscalar show(io, arr[])
+    return print(io, ")")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", arr::NDArray{T,0}) where {T}
-    println(io, "0-dimensional NDArray{$(T),0}")
-    allowscalar() do
-        return print(io, arr[])
-    end
+# Used by print(arr), println(arr), and nested displays
+function Base.show(io::IO, arr::NDArray)
+    return show(io, Array(arr))
 end
 
-function Base.show(io::IO, arr::NDArray{T,N}) where {T,N}
-    return print(io, "NDArray{$(T),$(N)} with size ", size(arr))
-end
+# Used for full REPL display
+function Base.show(io::IO, ::MIME"text/plain", arr::NDArray)
+    summary(io, arr)
 
-function Base.show(io::IO, ::MIME"text/plain", arr::NDArray{T,N}) where {T,N}
-    println(io, "NDArray{$(T),$(N)} with size ", size(arr))
+    isempty(arr) && return nothing
+
+    println(io, ":")
     return Base.print_array(io, Array(arr))
-end
-
-function Base.print(arr::NDArray{T}) where {T}
-    return Base.show(stdout, arr)
-end
-
-function Base.println(arr::NDArray{T}) where {T}
-    Base.show(stdout, arr)
-    return print("\n")
 end
 #### ARRAY INDEXING AND SLICES ####
 
@@ -324,7 +286,7 @@ end
 
 Overloads `Base.getindex` and `Base.setindex!` to support multidimensional indexing and slicing on `cuNumeric.NDArray`s.
 
-Slicing supports combinations of `Int`, `UnitRange`, and `Colon()` for selecting ranges of rows and columns.
+Slicing supports combinations of `Integer`, `UnitRange`, and `Colon()` for selecting ranges of rows and columns.
 The use of all colons (`arr[:]`, `arr[:, :]`, etc.) returns a new Julia `Array` containing a copy of the data.
 
 Assignment also supports:
@@ -341,10 +303,13 @@ Array(A)
 ```
  """
 ##### REGULAR ARRAY INDEXING ####
-function Base.getindex(arr::NDArray{T,N}, idxs::Vararg{Int,N}) where {T<:SUPPORTED_NUMERIC_TYPES,N}
+@inline function Base.getindex(
+    arr::NDArray{T,N}, idxs::Vararg{Integer,N}
+) where {T<:SUPPORTED_NUMERIC_TYPES,N}
+    @boundscheck checkbounds(arr, idxs...)
     assertscalar("getindex")
     acc = NDArrayAccessor{T,N}()
-    return read(acc, arr.ptr, to_cpp_index(idxs))
+    return read(acc, arr.ptr, to_cpp_index(Int.(idxs)))
 end
 
 function Base.getindex(arr::NDArray{T,0}) where {T<:SUPPORTED_NUMERIC_TYPES}
@@ -354,10 +319,11 @@ function Base.getindex(arr::NDArray{T,0}) where {T<:SUPPORTED_NUMERIC_TYPES}
     return read(acc, arr.ptr, zero_index)
 end
 
-function Base.getindex(arr::NDArray{Bool,N}, idxs::Vararg{Int,N}) where {N}
+@inline function Base.getindex(arr::NDArray{Bool,N}, idxs::Vararg{Integer,N}) where {N}
+    @boundscheck checkbounds(arr, idxs...)
     assertscalar("getindex")
     acc = NDArrayAccessor{CxxWrap.CxxBool,N}()
-    return read(acc, arr.ptr, to_cpp_index(idxs))
+    return read(acc, arr.ptr, to_cpp_index(Int.(idxs)))
 end
 
 function Base.getindex(arr::NDArray{Bool,0})
@@ -368,17 +334,26 @@ function Base.getindex(arr::NDArray{Bool,0})
 end
 
 #! TODO SUPPORT CONVERSION OF VALUES
-function Base.setindex!(arr::NDArray{T,N}, value::T, idxs::Vararg{Int,N}) where {T,N}
+@inline function Base.setindex!(
+    arr::NDArray{T,N}, value::T, idxs::Vararg{Integer,N}
+) where {T,N}
+    @boundscheck checkbounds(arr, idxs...)
     assertscalar("setindex!")
     return _setindex!(Val{N}(), arr, value, idxs...)
 end
 
-function Base.setindex!(arr::NDArray{Complex{T},N}, value::T, idxs::Vararg{Int,N}) where {T,N}
+@inline function Base.setindex!(
+    arr::NDArray{Complex{T},N}, value::T, idxs::Vararg{Integer,N}
+) where {T,N}
+    @boundscheck checkbounds(arr, idxs...)
     assertscalar("setindex!")
     return _setindex!(Val{N}(), arr, Complex{T}(value), idxs...)
 end
 
-function Base.setindex!(arr::NDArray{T,N}, value, idxs::Vararg{Int,N}) where {T,N}
+@inline function Base.setindex!(
+    arr::NDArray{T,N}, value, idxs::Vararg{Integer,N}
+) where {T,N}
+    @boundscheck checkbounds(arr, idxs...)
     assertscalar("setindex!")
     return _setindex!(Val{N}(), arr, convert(T, value), idxs...)
 end
@@ -394,15 +369,17 @@ function _setindex!(::Val{0}, arr::NDArray{Bool,0}, value::Bool)
 end
 
 function _setindex!(
-    ::Val{N}, arr::NDArray{T,N}, value::T, idxs::Vararg{Int,N}
+    ::Val{N}, arr::NDArray{T,N}, value::T, idxs::Vararg{Integer,N}
 ) where {T<:SUPPORTED_NUMERIC_TYPES,N}
     acc = NDArrayAccessor{T,N}()
-    return write(acc, arr.ptr, to_cpp_index(idxs), value)
+    return write(acc, arr.ptr, to_cpp_index(Int.(idxs)), value)
 end
 
-function _setindex!(::Val{N}, arr::NDArray{Bool,N}, value::Bool, idxs::Vararg{Int,N}) where {N}
+function _setindex!(
+    ::Val{N}, arr::NDArray{Bool,N}, value::Bool, idxs::Vararg{Integer,N}
+) where {N}
     acc = NDArrayAccessor{CxxWrap.CxxBool,N}()
-    return write(acc, arr.ptr, to_cpp_index(idxs), value)
+    return write(acc, arr.ptr, to_cpp_index(Int.(idxs)), value)
 end
 
 #### START OF SLICING ####
@@ -416,98 +393,183 @@ function _setindex_slice!(lhs::NDArray, rhs::NDArray, slices)
     return nothing
 end
 
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::Colon, j::Int64)
-    return _setindex_slice!(lhs, rhs, slice_array((0, Base.size(lhs, 1)), (j-1, j)))
-end
+@inline _zero_based_index(i::Integer) = (Int(i) - 1, Int(i))
+@inline _zero_based_range(i::AbstractUnitRange{<:Integer}) = (Int(first(i)) - 1, Int(last(i)))
 
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::Int64, j::Colon)
-    return _setindex_slice!(lhs, rhs, slice_array((i-1, i)))
-end
-
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::UnitRange, j::Colon)
+@inline function Base.setindex!(
+    lhs::NDArray{T,2}, rhs::NDArray, ::Colon, j::Integer
+) where {T}
+    @boundscheck checkbounds(lhs, :, j)
     return _setindex_slice!(
-        lhs, rhs, slice_array((first(i) - 1, last(i)), (0, Base.size(lhs, 2)))
+        lhs, rhs, slice_array((0, size(lhs, 1)), _zero_based_index(j))
     )
 end
 
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::Colon, j::UnitRange)
+@inline function Base.setindex!(
+    lhs::NDArray{T,2}, rhs::NDArray, i::Integer, ::Colon
+) where {T}
+    @boundscheck checkbounds(lhs, i, :)
+    return _setindex_slice!(lhs, rhs, slice_array(_zero_based_index(i)))
+end
+
+@inline function Base.setindex!(
+    lhs::NDArray{T,2}, rhs::NDArray, i::AbstractUnitRange{<:Integer}, ::Colon
+) where {T}
+    @boundscheck checkbounds(lhs, i, :)
     return _setindex_slice!(
-        lhs, rhs, slice_array((0, Base.size(lhs, 1)), (first(j) - 1, last(j)))
+        lhs, rhs, slice_array(_zero_based_range(i), (0, size(lhs, 2)))
     )
 end
 
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::UnitRange, j::Int64)
-    return _setindex_slice!(lhs, rhs, slice_array((first(i) - 1, last(i)), (j-1, j)))
-end
-
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::Int64, j::UnitRange)
-    return _setindex_slice!(lhs, rhs, slice_array((i-1, i), (first(j) - 1, last(j))))
-end
-
-function Base.setindex!(lhs::NDArray, rhs::NDArray, i::UnitRange, j::UnitRange)
+@inline function Base.setindex!(
+    lhs::NDArray{T,2}, rhs::NDArray, ::Colon, j::AbstractUnitRange{<:Integer}
+) where {T}
+    @boundscheck checkbounds(lhs, :, j)
     return _setindex_slice!(
-        lhs, rhs, slice_array((first(i) - 1, last(i)), (first(j) - 1, last(j)))
+        lhs, rhs, slice_array((0, size(lhs, 1)), _zero_based_range(j))
     )
 end
 
-function Base.getindex(arr::NDArray, i::Colon, j::Int64)
-    return nda_get_slice(arr, slice_array((0, Base.size(arr, 1)), (j-1, j)))
+@inline function Base.setindex!(
+    lhs::NDArray{T,2},
+    rhs::NDArray,
+    i::AbstractUnitRange{<:Integer},
+    j::Integer,
+) where {T}
+    @boundscheck checkbounds(lhs, i, j)
+    return _setindex_slice!(
+        lhs, rhs, slice_array(_zero_based_range(i), _zero_based_index(j))
+    )
 end
 
-function Base.getindex(arr::NDArray, i::Int64, j::Colon)
-    return nda_get_slice(arr, slice_array((i-1, i)))
+@inline function Base.setindex!(
+    lhs::NDArray{T,2},
+    rhs::NDArray,
+    i::Integer,
+    j::AbstractUnitRange{<:Integer},
+) where {T}
+    @boundscheck checkbounds(lhs, i, j)
+    return _setindex_slice!(
+        lhs, rhs, slice_array(_zero_based_index(i), _zero_based_range(j))
+    )
 end
 
-function Base.getindex(arr::NDArray, i::UnitRange, j::Colon)
+@inline function Base.setindex!(
+    lhs::NDArray{T,2},
+    rhs::NDArray,
+    i::AbstractUnitRange{<:Integer},
+    j::AbstractUnitRange{<:Integer},
+) where {T}
+    @boundscheck checkbounds(lhs, i, j)
+    return _setindex_slice!(
+        lhs, rhs, slice_array(_zero_based_range(i), _zero_based_range(j))
+    )
+end
+
+@inline function Base.getindex(arr::NDArray{T,2}, ::Colon, j::Integer) where {T}
+    @boundscheck checkbounds(arr, :, j)
     return nda_get_slice(
-        arr, slice_array((first(i) - 1, last(i)), (0, Base.size(arr, 2)))
+        arr, slice_array((0, size(arr, 1)), _zero_based_index(j))
     )
 end
 
-function Base.getindex(arr::NDArray, i::Colon, j::UnitRange)
+@inline function Base.getindex(arr::NDArray{T,2}, i::Integer, ::Colon) where {T}
+    @boundscheck checkbounds(arr, i, :)
+    return nda_get_slice(arr, slice_array(_zero_based_index(i)))
+end
+
+@inline function Base.getindex(
+    arr::NDArray{T,2}, i::AbstractUnitRange{<:Integer}, ::Colon
+) where {T}
+    @boundscheck checkbounds(arr, i, :)
     return nda_get_slice(
-        arr, slice_array((0, Base.size(arr, 1)), (first(j) - 1, last(j)))
+        arr, slice_array(_zero_based_range(i), (0, size(arr, 2)))
     )
 end
 
-function Base.getindex(arr::NDArray, i::UnitRange, j::Int64)
-    return nda_get_slice(arr, slice_array((first(i) - 1, last(i)), (j-1, j)))
-end
-
-function Base.getindex(arr::NDArray, i::Int64, j::UnitRange)
-    return nda_get_slice(arr, slice_array((i-1, i), (first(j) - 1, last(j))))
-end
-
-function Base.getindex(arr::NDArray, i::UnitRange, j::UnitRange)
+@inline function Base.getindex(
+    arr::NDArray{T,2}, ::Colon, j::AbstractUnitRange{<:Integer}
+) where {T}
+    @boundscheck checkbounds(arr, :, j)
     return nda_get_slice(
-        arr, slice_array((first(i) - 1, last(i)), (first(j) - 1, last(j)))
+        arr, slice_array((0, size(arr, 1)), _zero_based_range(j))
     )
 end
 
-function Base.getindex(arr::NDArray, i::UnitRange)
+@inline function Base.getindex(
+    arr::NDArray{T,2}, i::AbstractUnitRange{<:Integer}, j::Integer
+) where {T}
+    @boundscheck checkbounds(arr, i, j)
     return nda_get_slice(
-        arr, slice_array((first(i) - 1, last(i)))
+        arr, slice_array(_zero_based_range(i), _zero_based_index(j))
     )
 end
 
-Base.getindex(arr::NDArray{T}, c::Vararg{Colon,N}) where {T,N} = Base.copy(arr)
-function Base.setindex!(arr::NDArray{T}, rhs::NDArray{T}, c::Vararg{Colon,N}) where {T,N}
+@inline function Base.getindex(
+    arr::NDArray{T,2}, i::Integer, j::AbstractUnitRange{<:Integer}
+) where {T}
+    @boundscheck checkbounds(arr, i, j)
+    return nda_get_slice(
+        arr, slice_array(_zero_based_index(i), _zero_based_range(j))
+    )
+end
+
+@inline function Base.getindex(
+    arr::NDArray{T,2},
+    i::AbstractUnitRange{<:Integer},
+    j::AbstractUnitRange{<:Integer},
+) where {T}
+    @boundscheck checkbounds(arr, i, j)
+    return nda_get_slice(
+        arr, slice_array(_zero_based_range(i), _zero_based_range(j))
+    )
+end
+
+@inline function Base.getindex(
+    arr::NDArray, i::AbstractUnitRange{<:Integer}
+)
+    @boundscheck checkbounds(arr, i)
+    return nda_get_slice(arr, slice_array(_zero_based_range(i)))
+end
+
+@inline function Base.getindex(
+    arr::NDArray{T}, c::Vararg{Colon,N}
+) where {T,N}
+    @boundscheck checkbounds(arr, c...)
+    return Base.copy(arr)
+end
+
+@inline function Base.setindex!(
+    arr::NDArray{T}, rhs::NDArray{T}, c::Vararg{Colon,N}
+) where {T,N}
+    @boundscheck checkbounds(arr, c...)
     return Base.copyto!(arr, rhs)
 end
 
-function Base.setindex!(arr::NDArray{T,2}, val::T, i::Colon, j::Int64) where {T}
-    s = nda_get_slice(arr, slice_array((0, Base.size(arr, 1)), (j-1, j)))
+@inline function Base.setindex!(
+    arr::NDArray{T,2}, val::T, ::Colon, j::Integer
+) where {T}
+    @boundscheck checkbounds(arr, :, j)
+    s = nda_get_slice(
+        arr, slice_array((0, size(arr, 1)), _zero_based_index(j))
+    )
     nda_fill_array(s, val)
     return destroy!(s)
 end
 
-function Base.setindex!(arr::NDArray{T,2}, val::T, i::Int64, j::Colon) where {T}
-    s = nda_get_slice(arr, slice_array((i-1, i)))
+@inline function Base.setindex!(
+    arr::NDArray{T,2}, val::T, i::Integer, ::Colon
+) where {T}
+    @boundscheck checkbounds(arr, i, :)
+    s = nda_get_slice(arr, slice_array(_zero_based_index(i)))
     nda_fill_array(s, val)
     return destroy!(s)
 end
 
-Base.fill!(arr::NDArray{T}, val::T) where {T} = nda_fill_array(arr, val)
+@inline function Base.fill!(arr::NDArray{T}, val::T) where {T}
+    nda_fill_array(arr, val)
+    return arr
+end
 
 #### INITIALIZATION OF NDARRAYS ####
 @doc"""
@@ -725,8 +787,16 @@ function reshape(arr::NDArray, i::Int...; copy::Val{C}=Val(false)) where {C}
 end
 
 # Ignore the scalar indexing here...
-unwrap(x::NDArray{<:Any,0}) = @allowscalar x[]
-unwrap(x::NDArray{<:Any,1}) = @allowscalar x[][1] # assumes 1 element
+Base.only(x::NDArray{T,0}) where {T} = @allowscalar x[]
+
+function Base.only(x::NDArray{T,N}) where {T,N}
+    length(x) == 1 ||
+        throw(ArgumentError("collection must contain exactly 1 element"))
+
+    return @allowscalar x[firstindex(x)]
+end
+
+unwrap(x::NDArray) = only(x)
 
 @doc"""
     ==(arr1::NDArray, arr2::NDArray)

--- a/src/scoping.jl
+++ b/src/scoping.jl
@@ -114,7 +114,8 @@ function insert_finalizers(exprs::Vector, assigned_vars::Set{Symbol})
         return v
     end
 
-    is_indexed_assign(s) = s isa Expr && s.head == :(=) && !(s.args[1] isa Symbol)
+    is_indexed_assign(s) =
+        s isa Expr && s.head in (:(=), :(.=)) && !(s.args[1] isa Symbol)
     result_symbol(s) =
         if s isa Symbol
             s
@@ -312,6 +313,129 @@ end
 
 is_broadcast_op(op) = op isa Symbol && startswith(string(op), ".")
 
+function _is_broadcast_syntax(e)
+    return e isa Expr &&
+           (
+        (e.head == :call && !isempty(e.args) && is_broadcast_op(e.args[1])) ||
+        (e.head == :. && length(e.args) == 2)
+    )
+end
+
+function _symbol_occurrences(x, target::Symbol)
+    x === target && return 1
+    x isa Expr || return 0
+    return sum(arg -> _symbol_occurrences(arg, target), x.args; init=0)
+end
+
+function _substitute_symbols(x, replacements::Dict{Symbol,Any})
+    x isa Symbol && return get(replacements, x, x)
+    x isa Expr || return x
+
+    # A symbol assignment introduces/redefines its LHS; only substitute in RHS.
+    if x.head == :(=) && x.args[1] isa Symbol
+        return Expr(:(=), x.args[1], _substitute_symbols(x.args[2], replacements))
+    end
+    return Expr(x.head, (_substitute_symbols(arg, replacements) for arg in x.args)...)
+end
+
+function _indexed_assignment_base(stmt)
+    if stmt isa Expr && stmt.head == :(=) &&
+        stmt.args[1] isa Expr && stmt.args[1].head == :ref
+        base = stmt.args[1].args[1]
+        return base isa Symbol ? base : nothing
+    end
+    return nothing
+end
+
+function _safe_to_delay_broadcast(
+    stmts, def_idx::Int, use_idx::Int, dependencies::Set{Symbol}, lazy_defs::Set{Int}
+)
+    for i in (def_idx + 1):(use_idx - 1)
+        stmt = stmts[i]
+        stmt isa LineNumberNode && continue
+        i in lazy_defs && continue
+
+        # An indexed write to an unrelated array does not invalidate the lazy
+        # producer. Any other intervening statement is conservatively a barrier.
+        mutated = _indexed_assignment_base(stmt)
+        mutated !== nothing && !(mutated in dependencies) && continue
+        return false
+    end
+    return true
+end
+
+"""
+Inline single-use broadcast temporaries across statements before lifetime
+hoisting. This lets a stencil such as
+
+    lap = ...
+    out[slice] = scale .* lap .+ ...
+
+become one broadcast tree writing directly to `out[slice]`.
+
+Only broadcast definitions are delayed, and only across other lazy definitions
+or indexed writes to arrays not referenced by the producer.
+"""
+function inline_single_use_broadcasts(block)
+    Meta.isexpr(block, (:block, :begin)) || return block
+    stmts = collect(block.args)
+
+    definitions = Dict{Symbol,Tuple{Int,Any}}()
+    lazy_defs = Set{Int}()
+    for (i, stmt) in enumerate(stmts)
+        if stmt isa Expr && stmt.head == :(=) && stmt.args[1] isa Symbol &&
+            _is_broadcast_syntax(stmt.args[2])
+            definitions[stmt.args[1]] = (i, stmt.args[2])
+            push!(lazy_defs, i)
+        end
+    end
+
+    inlineable = Dict{Symbol,Tuple{Int,Int,Any}}()
+    for (sym, (def_idx, rhs)) in definitions
+        use_indices = Int[]
+        occurrences = 0
+        for i in (def_idx + 1):length(stmts)
+            n = _symbol_occurrences(stmts[i], sym)
+            if n > 0
+                occurrences += n
+                push!(use_indices, i)
+            end
+        end
+        occurrences == 1 || continue
+        use_idx = only(use_indices)
+        deps = Set(walk_symbols(rhs))
+        _safe_to_delay_broadcast(stmts, def_idx, use_idx, deps, lazy_defs) || continue
+        inlineable[sym] = (def_idx, use_idx, rhs)
+    end
+
+    replacements = Dict{Symbol,Any}()
+    removed = Set(first(info) for info in values(inlineable))
+    out = Any[]
+    for (i, stmt) in enumerate(stmts)
+        i in removed && begin
+            sym = only(sym for (sym, info) in inlineable if first(info) == i)
+            replacements[sym] = _substitute_symbols(inlineable[sym][3], replacements)
+            continue
+        end
+
+        stmt = _substitute_symbols(stmt, replacements)
+
+        # A materialized indexed assignment with a broadcast RHS normally
+        # allocates a temporary and copies it into the slice. If the destination
+        # base is absent from the RHS, write the fused tree directly to the view.
+        if stmt isa Expr && stmt.head == :(=) &&
+            stmt.args[1] isa Expr && stmt.args[1].head == :ref &&
+            _is_broadcast_syntax(stmt.args[2])
+            base = stmt.args[1].args[1]
+            if base isa Symbol && !(base in Set(walk_symbols(stmt.args[2])))
+                stmt = Expr(:(.=), stmt.args[1], stmt.args[2])
+            end
+        end
+        push!(out, stmt)
+    end
+    return Expr(block.head, out...)
+end
+
 function find_broadcast_assignments(ex, assigned_vars::Set{Symbol})
     local_assigned = Set{Symbol}()
 
@@ -335,16 +459,32 @@ function find_broadcast_assignments(ex, assigned_vars::Set{Symbol})
 
     # Inside a broadcast tree: hoist slices, keep dotted ops/f.(…) lazy, and
     # delegate anything else to rewrite() (it breaks the tree → real NDArray).
-    function rewrite_bcast(e)::Tuple{Any,Vector{Expr}}
+    #
+    # The slice cache is deliberately scoped to one fused tree. Repeated views
+    # then become one task argument and are still destroyed immediately after
+    # that task's last use. Sharing the cache across trees would keep transformed
+    # stores alive across task submissions, which can force runtime copies and
+    # delay device-memory reclamation.
+    function rewrite_bcast(e, slice_cache::Dict{Any,Symbol})::Tuple{Any,Vector{Expr}}
         e isa Expr || return e, Expr[]
-        e.head == :ref && return fresh_tmp(e)
+        if e.head == :ref
+            cached = get(slice_cache, e, nothing)
+            cached === nothing || return cached, Expr[]
+            tmp, bind = fresh_tmp(e)
+            slice_cache[e] = tmp
+            return tmp, bind
+        end
         if e.head == :call && is_broadcast_op(e.args[1])
-            args, hoisted = maphoist(rewrite_bcast, e.args[2:end])
+            args, hoisted = maphoist(
+                x -> rewrite_bcast(x, slice_cache), e.args[2:end]
+            )
             return Expr(:call, e.args[1], args...), hoisted
         end
         if e.head == :. && length(e.args) == 2 &&
             e.args[2] isa Expr && e.args[2].head == :tuple
-            args, hoisted = maphoist(rewrite_bcast, e.args[2].args)
+            args, hoisted = maphoist(
+                x -> rewrite_bcast(x, slice_cache), e.args[2].args
+            )
             return Expr(:., e.args[1], Expr(:tuple, args...)), hoisted
         end
         return rewrite(e)
@@ -363,8 +503,27 @@ function find_broadcast_assignments(ex, assigned_vars::Set{Symbol})
         # .= RHS is a broadcast tree: only the slices inside it are hoisted.
         if e.head == :(.=)
             lhs, rhs = e.args
-            new_lhs, lts = rewrite(lhs)
-            new_rhs, rts = rewrite_bcast(rhs)
+            # Preserve Julia's indexed `.=` semantics. Hoisting `A[inds...]`
+            # directly is valid for NDArray (whose getindex returns a view), but
+            # produces a detached copy for Array. An explicit view works for
+            # both, while still giving the lifetime pass a concrete NDArray
+            # wrapper to destroy immediately after task submission.
+            new_lhs, lts =
+                if lhs isa Expr && lhs.head == :ref
+                    view_expr = Base.macroexpand(
+                        @__MODULE__,
+                        Expr(
+                            :macrocall,
+                            GlobalRef(Base, Symbol("@view")),
+                            LineNumberNode(0),
+                            lhs,
+                        ),
+                    )
+                    fresh_tmp(view_expr)
+                else
+                    rewrite(lhs)
+                end
+            new_rhs, rts = rewrite_bcast(rhs, Dict{Any,Symbol}())
             return Expr(:(.=), new_lhs, new_rhs), vcat(lts, rts)
         end
 
@@ -372,7 +531,7 @@ function find_broadcast_assignments(ex, assigned_vars::Set{Symbol})
 
         # Broadcast root: hoist the fused result as one temp.
         if e.head == :call && is_broadcast_op(e.args[1])
-            inner, hoisted = rewrite_bcast(e)
+            inner, hoisted = rewrite_bcast(e, Dict{Any,Symbol}())
             tmp, bind = fresh_tmp(inner)
             return tmp, vcat(hoisted, bind)
         end
@@ -411,6 +570,7 @@ end
 
 function process_broadcast_scope(block)
     assigned_vars = Set{Symbol}()
+    block = inline_single_use_broadcasts(block)
     rewritten = find_broadcast_assignments(block, assigned_vars)
     result = insert_finalizers(rewritten, assigned_vars)
     counter[] = 0

--- a/test/tests/broadcast_fusion_tests.jl
+++ b/test/tests/broadcast_fusion_tests.jl
@@ -430,6 +430,20 @@ function test_broadcast_fusion_edge_cases(; T=Float32, atol=1e-5, rtol=1e-5)
         a2 .= a2 .* s1 .+ b
         @allowscalar @test cuNumeric.compare(ja .* s1 .+ jb, a2, atol, rtol)
     end
+
+    @testset "cross-statement fusion into a slice" begin
+        N = 16
+        ja = reshape(T.(1:(N * N)), N, N)
+        a = @allowscalar NDArray(ja)
+        out = cuNumeric.zeros(T, (N + 2, N + 2))
+        @analyze_lifetimes begin
+            producer = a .* s1
+            out[2:(end - 1), 2:(end - 1)] = producer .+ s2
+        end
+        expected = zeros(T, N + 2, N + 2)
+        expected[2:(end - 1), 2:(end - 1)] = ja .* s1 .+ s2
+        @allowscalar @test cuNumeric.compare(expected, out, atol, rtol)
+    end
 end
 
 #= Broadcast fusion PTX compilation cache.

--- a/test/tests/broadcast_fusion_tests.jl
+++ b/test/tests/broadcast_fusion_tests.jl
@@ -197,7 +197,7 @@ function test_broadcast_fusion(; T=Float32, N=100, atol=1e-5, rtol=1e-5)
     end
 end
 
-#= Edge cases for linear-only broadcast fusion.
+#= Edge cases for same-shaped broadcast fusion.
  * Complements `test_broadcast_fusion` with size extremes, 2D same-shape,
  * fusion gating for shape mismatch, 0-d fallback, and dest/input aliasing.
 =#
@@ -271,6 +271,17 @@ function test_broadcast_fusion_edge_cases(; T=Float32, atol=1e-5, rtol=1e-5)
         dest = cuNumeric.zeros(T, M, N)
         bc = Base.Broadcast.instantiate(Base.broadcasted(+, a, b))
         @test cuNumeric.can_fuse_linear_broadcast(dest, bc)
+    end
+
+    @testset "2D Cartesian launch shapes" begin
+        for (M, N) in ((1, 513), (513, 1), (37, 513))
+            ja = rand(T, M, N)
+            jb = rand(T, M, N)
+            a = @allowscalar NDArray(ja)
+            b = @allowscalar NDArray(jb)
+            result = a .+ b .* s1
+            @allowscalar @test cuNumeric.compare(ja .+ jb .* s1, result, atol, rtol)
+        end
     end
 
     @testset "scalar gaps: A .^ 2 and scalar*A*scalar" begin

--- a/test/tests/scoping.jl
+++ b/test/tests/scoping.jl
@@ -106,6 +106,20 @@ function test_scoping_regressions(T, N)
         @test res isa cuNumeric.NDArray
         @test all(Array(res) .== T(4.0))
     end
+
+    if cuNumeric.FUSE_BROADCAST_EXPRS
+        @testset "Indexed fused assignment preserves Array view semantics" begin
+            src = reshape(T.(1:20), 4, 5)
+            out = fill(T(-1), 6, 7)
+            @analyze_lifetimes begin
+                producer = src .* T(2)
+                out[2:(end - 1), 2:(end - 1)] = producer .+ T(1)
+            end
+            @test out[2:(end - 1), 2:(end - 1)] == src .* T(2) .+ T(1)
+            @test all(out[[1, end], :] .== T(-1))
+            @test all(out[:, [1, end]] .== T(-1))
+        end
+    end
 end
 
 function run_all_ops(FT, N)


### PR DESCRIPTION
This requires `AbstractNDArray <: AbstractArray`. I have added that and fixed several things that were not commensurate with the typical Julia array interface.

This also adds constructors for `LinearAlgebra.Diagonal` specialized operators and functions related to `LinearAlgebra.I` (identity matrix).