### PR TITLE
Reduction tolerances scaling w/ N

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,9 +166,13 @@ end
                 cunumeric_res = reduction(cunumeric_arr)
                 julia_res = reduction(julia_arr)
 
+                n = length(julia_arr)
                 allowscalar() do
                     # assumes 0D result
-                    @test isapprox(julia_res, cunumeric_res[]; atol=atol(T), rtol=rtol(T))
+                    @test isapprox(
+                        julia_res, cunumeric_res[];
+                        atol=reduction_atol(T, n), rtol=reduction_rtol(T, n),
+                    )
                 end
             end
         end
@@ -283,7 +287,7 @@ end
 @testset "Copy-To" begin
     a = cuNumeric.zeros(2, 2)
     b = cuNumeric.ones(2, 2)
-    copyto!(a, b);
+    copyto!(a, b)
     @test is_same(a, b)
 end
 

--- a/test/tests/unary_tests.jl
+++ b/test/tests/unary_tests.jl
@@ -96,8 +96,11 @@ function test_unary_reduction_dims(
         for d in 1:N
             julia_res = func(julia_arr; dims=d)
             cunumeric_res = func(cunumeric_arr; dims=d)
+            n = size(julia_arr, d)
             allowscalar() do
-                @test cuNumeric.compare(julia_res, cunumeric_res, atol(T), rtol(T))
+                @test cuNumeric.compare(
+                    julia_res, cunumeric_res, reduction_atol(T, n), reduction_rtol(T, n)
+                )
             end
         end
 

--- a/test/tests/util.jl
+++ b/test/tests/util.jl
@@ -38,6 +38,10 @@ atol(::Type{I}) where {I<:Integer} = atol(float(I))
 rtol(::Type{Complex{T}}) where {T} = rtol(T)
 atol(::Type{Complex{T}}) where {T} = atol(T)
 
+# Reduction rounding error grows with the number of elements reduced (n).
+reduction_rtol(::Type{T}, n) where {T} = rtol(T) * n
+reduction_atol(::Type{T}, n) where {T} = atol(T) * n
+
 is_same(arr1::NDArray, arr2::NDArray) = @allowscalar (arr1 == arr2)[1]
 is_same(arr1::NDArray, arr2::Array) = @allowscalar (arr1 == arr2)[1]
 is_same(arr1::Array, arr2::NDArray) = @allowscalar (arr1 == arr2)[1]


### PR DESCRIPTION
Ran an iterative reduction test. On iteration 176, we had a precision error. It is incredibly rare; however, the solution is to scale the tolerance by the number of elements. 