### PR TITLE
Add more linear algebra ops (i.e., eigen)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,3 +60,30 @@ points so they do not fall through to scalar-indexing Base paths.
 - Still fallthrough / unsupported on `Diagonal` (e.g. `svd`, `pinv`,
   `cholesky`, host `AbstractArray` RHS): leave alone unless fixing is cheap;
   densify intentionally when needed
+
+**Decompositions**
+- Done: `cholesky`, `eigen` / `eigvals` / `eigvecs`, `svd`, `qr`, and `\` are
+  wired to `LinearAlgebra` for 2D `NDArray`; `batched_solve` / `batched_cholesky`
+  / `batched_eigen` / `batched_eigvals` cover one batch dimension
+- `eigh` / Hermitian eigen — the `SYEV` task is already wrapped, but there is no
+  entry point until `Hermitian` / `Symmetric` work on `NDArray`
+- `PosDefException` from `cholesky` — a non-positive-definite input now raises a
+  catchable `ErrorException` (since the launchers call `task_throws_exception`),
+  but mapping it onto `LinearAlgebra.PosDefException` needs the failing pivot
+  index, which the task message does not carry
+- The decomposition launchers must keep calling `task_throws_exception`, as
+  cupynumeric's own launchers do. Besides propagating task exceptions it grows
+  each leaf allocation pool by `--max-exception-size` (4096 bytes), which the
+  batched GPU kernels depend on: `CuPyNumericMapper::allocation_pool_size` only
+  declares one 16-byte-aligned `int32` of ZCMEM for `SOLVE` / `GEEV`, while
+  `solve.cu` allocates `batchsize` pointer arrays plus `batchsize` infos and
+  `geev.cu` allocates an info per matrix. Without it, `b > 1` aborts on GPU
+- `adjoint(::NDArray)` (already on the P1 list) would unblock `Cholesky.U`,
+  `SVD.V`, destructuring a `Cholesky` as `L, U`, and `ldiv!` / least-squares `\`
+  on `NDArrayQR` (which needs `Q' * b`)
+- More than one batch dimension — needs `domain_from_shape` in Legate.jl to
+  handle more than three dimensions, plus a cupynumeric `POTRF` instantiated for
+  `DIM >= 4`
+- Multi-GPU cuSolverMp paths (`MP_POTRF`, `MP_SOLVE`) for large single matrices;
+  `cupynumeric_has_cusolvermp()` gates them and they need an NCCL communicator
+- Batched `svd` / `qr`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,6 +4,6 @@ Indexing, reshaping, reductions, comparisons, memory helpers, lifetime macros, a
 
 ```@autodocs
 Modules = [cuNumeric]
-Pages = ["ndarray/ndarray.jl", "ndarray/linalg.jl", "cuNumeric.jl", "warnings.jl", "util.jl", "memory.jl", "scoping/scoping.jl"]
+Pages = ["ndarray/ndarray.jl", "ndarray/linalg.jl", "ndarray/batched_linalg.jl", "cuNumeric.jl", "warnings.jl", "util.jl", "memory.jl", "scoping/scoping.jl"]
 Filter = t -> !(t isa Function && nameof(t) in (:zeros, :ones, :fill, :trues, :falses, :eye, :rand, :rand!, :randn, :randn!, :randexp, :randexp!, :default_rng, :random, :random!))
 ```

--- a/docs/src/linalg.md
+++ b/docs/src/linalg.md
@@ -1,11 +1,26 @@
 # Linear Algebra
 
-cuNumeric.jl provides matrix multiplication, batched solves, SVD, QR, and related
-helpers for `NDArray`.
+cuNumeric.jl provides matrix multiplication, solves, Cholesky, eigen, SVD, QR,
+and related helpers for `NDArray`.
 
-`solve`, `svd`, and `qr` accept `Float32`, `Float64`, `ComplexF32`, and
+All of the decompositions accept `Float32`, `Float64`, `ComplexF32`, and
 `ComplexF64`. Integer and `Bool` inputs require `@allowpromotion` or
 `allowpromotion` and produce `Float64` outputs.
+
+## Which entry point to use
+
+Single matrices go through the standard `LinearAlgebra` functions and return the
+standard factorization objects. Stacks of matrices have no `LinearAlgebra`
+equivalent, so they get their own `batched_*` names.
+
+| Single matrix (2D) | Returns | Stack of matrices (3D) |
+| --- | --- | --- |
+| `LinearAlgebra.cholesky(A)` | `Cholesky` | `cuNumeric.batched_cholesky(A)` |
+| `LinearAlgebra.eigen(A)` | `Eigen` | `cuNumeric.batched_eigen(A)` |
+| `LinearAlgebra.eigvals(A)` | `NDArray` | `cuNumeric.batched_eigvals(A)` |
+| `LinearAlgebra.svd(A)` | `SVD` | not supported |
+| `LinearAlgebra.qr(A)` | `NDArrayQR` | not supported |
+| `cuNumeric.solve(A, b)`, `A \ b` | `NDArray` | `cuNumeric.batched_solve(A, B)` |
 
 ## Matrix multiply
 
@@ -29,52 +44,139 @@ Pages = ["ndarray/binary.jl"]
 Filter = t -> t isa Function && nameof(t) === :mul!
 ```
 
-## Solve (batched)
+## Solve
 
-`cuNumeric.solve(A, b)` solves linear systems and returns an array with the same
-shape as `b`. `A` has shape `(..., m, m)` and `b` has shape `(..., m)` or
-`(..., m, n)`.
+`cuNumeric.solve(A, b)` solves a linear system and returns an array with the same
+shape as `b`. `A` is a square `m × m` matrix and `b` has shape `(m,)` or
+`(m, n)`. `A \ b` is equivalent.
 
 ```julia
 A = cuNumeric.rand(Float32, 64, 64)
 b = cuNumeric.rand(Float32, 64)
-x = cuNumeric.solve(A, b)
+x = cuNumeric.solve(A, b)     # or: A \ b
 
 B = cuNumeric.rand(Float32, 64, 4)
-X = cuNumeric.solve(A, B)
-
-As = cuNumeric.rand(Float32, 8, 32, 32)
-Bs = cuNumeric.rand(Float32, 8, 32, 2)
-Xs = cuNumeric.solve(As, Bs)
+X = A \ B
 ```
+
+## Cholesky
+
+`LinearAlgebra.cholesky(A)` returns a `Cholesky` object holding the lower factor
+`L`, with `A ≈ L * L'`.
+
+```julia
+using LinearAlgebra
+
+A = cuNumeric.rand(Float32, 64, 64)
+A = A * cuNumeric.transpose(A) + 64 * NDArray{Float32}(I, 64, 64)  # make it SPD
+
+F = cholesky(A)
+L = F.L          # LowerTriangular view of F.factors
+```
+
+Three things differ from Base:
+
+- The input is **not** checked for being Hermitian; only its lower triangle is
+  read. There are no `Hermitian` / `Symmetric` overloads.
+- A non-positive-definite input raises an `ErrorException` carrying the task's
+  `"Matrix is not positive definite"` message, not a `PosDefException`. The
+  `check` keyword is therefore not supported.
+- `F.U` (and hence destructuring as `L, U = F`) needs `copy(F.factors')`, which
+  falls back to scalar indexing until `adjoint(::NDArray)` is implemented. Use
+  `F.L` or `F.factors`.
+
+## Eigendecomposition
+
+`LinearAlgebra.eigen(A)` returns an `Eigen` object; `eigvals` and `eigvecs`
+return the pieces individually. Column `j` of the eigenvector matrix is the
+eigenvector for eigenvalue `j`.
+
+```julia
+A = cuNumeric.rand(Float64, 64, 64)
+
+F = eigen(A)
+values, vectors = F      # or: eigvals(A), eigvecs(A)
+```
+
+Eigenvalues and eigenvectors are **always complex**, even when `A` is real with
+real eigenvalues: `ComplexF32` for `Float32` / `ComplexF32` input and
+`ComplexF64` otherwise. This follows the underlying LAPACK `geev` path and
+differs from Base, which returns real factors for such input. CUDA.jl's
+non-symmetric branch behaves the same way.
+
+On a GPU this requires `cusolverDnXgeev`, added in CUDA 12.6.2. When it is
+missing, the eigen entry points throw an error rather than silently falling back
+to host execution.
+
+The symmetric/Hermitian path (`eigh`, backed by the `SYEV` task) is not wired up
+yet; it needs `Hermitian` / `Symmetric` support on `NDArray` first.
 
 ## Singular value decomposition
 
-`cuNumeric.svd(A, full_matrices=true)` returns `(U, S, Vh)` for a 2D `m × n`
-array. With `k = min(m, n)`, the output shapes are:
-
-- Full: `U` is `m × m`, `S` has length `k`, and `Vh` is `n × n`.
-- Thin: `U` is `m × k`, `S` has length `k`, and `Vh` is `k × n`.
+`LinearAlgebra.svd(A; full=false)` returns an `SVD` object with
+`A ≈ F.U * Diagonal(F.S) * F.Vt`.
 
 ```julia
 A = cuNumeric.rand(Float32, 128, 64)
-U, S, Vh = cuNumeric.svd(A, false)
+F = svd(A)
+U, S, Vt = F.U, F.S, F.Vt
 ```
+
+With `k = min(m, n)`, the output shapes are:
+
+- Thin (`full=false`, the default): `U` is `m × k`, `S` has length `k`, and `Vt`
+  is `k × n`.
+- Full (`full=true`): `U` is `m × m`, `S` has length `k`, and `Vt` is `n × n`.
+
+Note that `full=false` is the Julia default, whereas numpy's
+`full_matrices=True` is not. Destructuring as `U, S, V = F` also gives you the
+*adjoint* of `F.Vt`, and `F.V` is a lazy `Adjoint` wrapper, so operating on it
+falls back to scalar indexing until `adjoint(::NDArray)` is implemented. Prefer
+`F.Vt`.
 
 `S` is real-valued for both real and complex inputs.
 
 ## QR decomposition
 
-`cuNumeric.qr(A)` returns the economy-size factors `(Q, R)` for a 2D `m × n`
-array. With `k = min(m, n)`, `Q` is `m × k` and `R` is `k × n`.
+`LinearAlgebra.qr(A)` returns an `NDArrayQR`, holding the economy-size factors
+with `A ≈ F.Q * F.R`. For a 2D `m × n` input and `k = min(m, n)`, `Q` is `m × k`
+and `R` is `k × n`.
 
 ```julia
 A = cuNumeric.rand(Float32, 128, 64)
-Q, R = cuNumeric.qr(A)
+F = qr(A)
+Q, R = F                 # or: F.Q, F.R
 ```
 
-SVD and QR currently accept only 2D arrays; batched decompositions are not
-supported.
+`NDArrayQR` is a `LinearAlgebra.Factorization` but not one of Base's QR types.
+Base's default `QRCompactWY` stores a blocked Householder representation and
+`QR` stores `factors` plus `τ`; the backend runs `geqrf` followed by `orgqr` and
+discards `τ`, so neither is constructible. The practical difference is that
+`F.Q` is a materialized `NDArray` rather than a lazy `QRCompactWYQ`.
+
+SVD and QR accept only 2D arrays; there are no batched versions.
+
+## Batched decompositions
+
+The `batched_*` functions apply an operation to every matrix in a stack. They
+take exactly one batch dimension, i.e. shape `(b, m, m)`, and return plain
+tuples or arrays rather than factorization objects.
+
+```julia
+As = cuNumeric.rand(Float32, 8, 32, 32)
+Bs = cuNumeric.rand(Float32, 8, 32, 2)
+
+Xs = cuNumeric.batched_solve(As, Bs)         # (8, 32, 2)
+Ls = cuNumeric.batched_cholesky(As)          # (8, 32, 32), needs SPD blocks
+values, vectors = cuNumeric.batched_eigen(As)  # (8, 32) and (8, 32, 32)
+```
+
+Each matrix is factored on a single processor, so this is a good fit for many
+small matrices and a poor one for a few large ones. Two or more batch dimensions
+are rejected: the `POTRF` task body is only instantiated up to three dimensions,
+and Legate.jl builds launch domains for at most three dimensions.
+
+Every caveat listed under Cholesky and Eigendecomposition applies here too.
 
 ## Helpers
 
@@ -188,6 +290,10 @@ scale or shift; prefer `Diagonal` and `I` instead. There is no public `eye`.
 
 ## Not available yet
 
-There is no public dense-matrix `cholesky`, `eig`, `lu`, matrix `inv`, or
-`ldiv!` yet (beyond the `Diagonal` / `NDArray` paths listed above).
-Elementwise `inv` / `^-1` are unary operations, not matrix inverse.
+There is no public dense-matrix `lu`, matrix `inv`, or `ldiv!` yet (beyond the
+`Diagonal` / `NDArray` paths listed above). Elementwise `inv` / `^-1` are unary
+operations, not matrix inverse.
+
+Also missing: `eigh` / Hermitian eigen (needs `Hermitian` and `Symmetric`
+support on `NDArray`), batched SVD and QR, and the multi-GPU cuSolverMp paths
+for Cholesky and solve.

--- a/docs/src/linalg.md
+++ b/docs/src/linalg.md
@@ -4,8 +4,10 @@ cuNumeric.jl provides matrix multiplication, solves, Cholesky, eigen, SVD, QR,
 and related helpers for `NDArray`.
 
 All of the decompositions accept `Float32`, `Float64`, `ComplexF32`, and
-`ComplexF64`. Integer and `Bool` inputs require `@allowpromotion` or
-`allowpromotion` and produce `Float64` outputs.
+`ComplexF64`. Integer and `Bool` inputs are converted to `Float64`. As
+everywhere else in the package, that conversion needs `@allowpromotion` (or
+`allowpromotion`) only when it widens the element type, so `Int64` and `UInt64`
+pass through silently while `Int32`, smaller integers, and `Bool` do not.
 
 ## Which entry point to use
 

--- a/lib/cunumeric_jl_wrapper/src/types.cpp
+++ b/lib/cunumeric_jl_wrapper/src/types.cpp
@@ -171,6 +171,8 @@ void wrap_linalg_ops(jlcxx::Module& mod) {
                 legate::LocalTaskID{CuPyNumericOpCode::CUPYNUMERIC_MP_SOLVE});
   mod.set_const("SVD", legate::LocalTaskID{CuPyNumericOpCode::CUPYNUMERIC_SVD});
   mod.set_const("CQR", legate::LocalTaskID{CuPyNumericOpCode::CUPYNUMERIC_QR});
+  mod.set_const("POTRF",
+                legate::LocalTaskID{CuPyNumericOpCode::CUPYNUMERIC_POTRF});
   mod.set_const("SYEV",
                 legate::LocalTaskID{CuPyNumericOpCode::CUPYNUMERIC_SYEV});
   mod.set_const("GEEV",

--- a/lib/cunumeric_jl_wrapper/src/wrapper.cpp
+++ b/lib/cunumeric_jl_wrapper/src/wrapper.cpp
@@ -55,6 +55,19 @@ void* nda_store_to_ndarray(legate::LogicalStore st) {
   return static_cast<void*>(new CN_NDArray{cupynumeric::as_array(st)});
 }
 
+// Legate.jl wraps ManualTask::add_input/add_output for a whole partition, but
+// not the overloads taking a projection. GEEV needs one: its eigenvalue store
+// has one fewer dimension than the launch domain. Julia picks the source
+// dimensions; this only translates them into a SymbolicPoint.
+static legate::SymbolicPoint make_projection(const std::vector<int32_t>& dims) {
+  std::vector<legate::SymbolicExpr> exprs;
+  exprs.reserve(dims.size());
+  for (auto d : dims) {
+    exprs.push_back(legate::dimension(static_cast<uint32_t>(d)));
+  }
+  return legate::SymbolicPoint{std::move(exprs)};
+}
+
 #if LEGATE_DEFINED(LEGATE_USE_CUDA)
 void register_tasks() {
   auto library = get_lib();
@@ -98,6 +111,35 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
   mod.method("_get_store", &get_store);
   mod.method("get_lib", &get_lib);
   mod.method("nda_store_to_ndarray", &nda_store_to_ndarray);
+
+  // True when the loaded cuSolver provides cusolverDnXgeev. Without it
+  // cupynumeric has no GPU eigenvalue kernel for general matrices.
+  mod.method("cusolver_has_geev", &cupynumeric_cusolver_has_geev);
+
+  mod.method("add_input_proj",
+             [](legate::ManualTask& task,
+                std::shared_ptr<legate::LogicalStorePartition> part,
+                const std::vector<int32_t>& dims) {
+               task.add_input(*part, make_projection(dims));
+             });
+  mod.method("add_output_proj",
+             [](legate::ManualTask& task,
+                std::shared_ptr<legate::LogicalStorePartition> part,
+                const std::vector<int32_t>& dims) {
+               task.add_output(*part, make_projection(dims));
+             });
+
+  // Marking a task as throwing also grows its leaf allocation pools by
+  // --max-exception-size (4096 bytes by default), which the cupynumeric
+  // decomposition tasks rely on: their mapper only declares enough zero-copy
+  // memory for a single status flag, while the batched GPU kernels allocate one
+  // per matrix. cupynumeric's own Python launchers always set this.
+  mod.method("task_throws_exception", [](legate::ManualTask& task, bool value) {
+    task.throws_exception(value);
+  });
+  mod.method("task_throws_exception", [](legate::AutoTask& task, bool value) {
+    task.throws_exception(value);
+  });
 
   // Legate.jl Scalar has no vector constructors. BITGENERATOR (and similar)
   // tasks take fixed-array scalars; these helpers pack them from Julia

--- a/src/cuNumeric.jl
+++ b/src/cuNumeric.jl
@@ -74,6 +74,8 @@ const SUPPORTED_NUMERIC_TYPES = Union{
 const SUPPORTED_SOLVE_TYPES = Union{SUPPORTED_FLOAT_TYPES,SUPPORTED_COMPLEX_TYPES}
 const SUPPORTED_SVD_TYPES = Union{SUPPORTED_FLOAT_TYPES,SUPPORTED_COMPLEX_TYPES}
 const SUPPORTED_QR_TYPES = Union{SUPPORTED_FLOAT_TYPES,SUPPORTED_COMPLEX_TYPES}
+const SUPPORTED_CHOLESKY_TYPES = Union{SUPPORTED_FLOAT_TYPES,SUPPORTED_COMPLEX_TYPES}
+const SUPPORTED_EIG_TYPES = Union{SUPPORTED_FLOAT_TYPES,SUPPORTED_COMPLEX_TYPES}
 const SUPPORTED_ARRAY_TYPES = Union{Bool,SUPPORTED_NUMERIC_TYPES}
 const SUPPORTED_TYPES = Union{SUPPORTED_ARRAY_TYPES,String}
 
@@ -180,6 +182,7 @@ include("ndarray/random/random.jl")
 include("ndarray/unary.jl")
 include("ndarray/binary.jl")
 include("ndarray/linalg.jl")
+include("ndarray/batched_linalg.jl")
 include("scoping/scoping.jl")
 
 # From https://github.com/JuliaGraphics/QML.jl/blob/dca239404135d85fe5d4afe34ed3dc5f61736c63/src/QML.jl#L147

--- a/src/ndarray/batched_linalg.jl
+++ b/src/ndarray/batched_linalg.jl
@@ -14,17 +14,18 @@ Solve a stack of linear systems `A * X = B`.
 same shape as `B`.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 
 For a single system use [`cuNumeric.solve`](@ref).
 """
-function batched_solve(a::NDArray{<:_SOLVE_ACCEPTED}, b::NDArray{<:_SOLVE_ACCEPTED})
-    A, B = eltype(a), eltype(b)
+function batched_solve(
+    a::NDArray{A}, b::NDArray{B}
+) where {A<:_SOLVE_ACCEPTED,B<:_SOLVE_ACCEPTED}
     O = promote_type(_solve_eltype(A), _solve_eltype(B))
-    A <: _SOLVE_PROMOTABLE && assertpromotion(batched_solve, A, O)
-    B <: _SOLVE_PROMOTABLE && assertpromotion(batched_solve, B, O)
     return _solve_check_a_dims_batched(
-        unchecked_promote_arr(a, O), unchecked_promote_arr(b, O)
+        checked_promote_arr(batched_solve, a, O), checked_promote_arr(batched_solve, b, O)
     )
 end
 
@@ -44,14 +45,13 @@ triangular `L` with `A[i, :, :] ≈ L * L'`; the upper triangle is zeroed.
 triangle is read and Hermitian-ness is not checked.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 """
-function batched_cholesky(a::NDArray{<:_CHOLESKY_ACCEPTED,N}) where {N}
+function batched_cholesky(a::NDArray{T,N}) where {T<:_CHOLESKY_ACCEPTED,N}
     _assert_batched_dims(:batched_cholesky, N)
-    A = eltype(a)
-    O = _cholesky_eltype(A)
-    A <: _CHOLESKY_PROMOTABLE && assertpromotion(batched_cholesky, A, O)
-    return _cholesky(unchecked_promote_arr(a, O))
+    return _cholesky(checked_promote_arr(batched_cholesky, a, _cholesky_eltype(T)))
 end
 
 function batched_cholesky(a::NDArray)
@@ -68,9 +68,9 @@ the shape of `A`, with `vectors[i, :, j]` the eigenvector for `values[i, j]`.
 
 Both results are always complex, even for real input. See `LinearAlgebra.eigen`.
 """
-function batched_eigen(a::NDArray{<:_EIG_ACCEPTED,N}) where {N}
+function batched_eigen(a::NDArray{T,N}) where {T<:_EIG_ACCEPTED,N}
     _assert_batched_dims(:batched_eigen, N)
-    return _eig(_promote_for_eig(a))
+    return _eig(checked_promote_arr(batched_eigen, a, _eig_eltype(T)))
 end
 
 function batched_eigen(a::NDArray)
@@ -83,9 +83,9 @@ end
 Eigenvalues of every matrix in the stack `A`, as a complex array of shape
 `(b, m)`. See [`cuNumeric.batched_eigen`](@ref).
 """
-function batched_eigvals(a::NDArray{<:_EIG_ACCEPTED,N}) where {N}
+function batched_eigvals(a::NDArray{T,N}) where {T<:_EIG_ACCEPTED,N}
     _assert_batched_dims(:batched_eigvals, N)
-    return _eigvals(_promote_for_eig(a))
+    return _eigvals(checked_promote_arr(batched_eigvals, a, _eig_eltype(T)))
 end
 
 function batched_eigvals(a::NDArray)

--- a/src/ndarray/batched_linalg.jl
+++ b/src/ndarray/batched_linalg.jl
@@ -1,0 +1,93 @@
+# Batched linear algebra: operations over a stack of matrices, dispatching on 3D
+# arrays. These have no Base.LinearAlgebra counterpart, so they keep the
+# `batched_` prefix and return plain tuples rather than `Factorization` objects.
+#
+# All of them take exactly one batch dimension, i.e. shape (b, m, m). See
+# `MAX_BATCHED_DIM` for why.
+
+"""
+    cuNumeric.batched_solve(A, B)
+
+Solve a stack of linear systems `A * X = B`.
+
+`A` must have shape `(b, m, m)` and `B` shape `(b, m, n)`. The result has the
+same shape as `B`.
+
+Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
+Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+
+For a single system use [`cuNumeric.solve`](@ref).
+"""
+function batched_solve(a::NDArray{<:_SOLVE_ACCEPTED}, b::NDArray{<:_SOLVE_ACCEPTED})
+    A, B = eltype(a), eltype(b)
+    O = promote_type(_solve_eltype(A), _solve_eltype(B))
+    A <: _SOLVE_PROMOTABLE && assertpromotion(batched_solve, A, O)
+    B <: _SOLVE_PROMOTABLE && assertpromotion(batched_solve, B, O)
+    return _solve_check_a_dims_batched(
+        unchecked_promote_arr(a, O), unchecked_promote_arr(b, O)
+    )
+end
+
+function batched_solve(a::NDArray, b::NDArray)
+    bad = eltype(a) <: _SOLVE_ACCEPTED ? eltype(b) : eltype(a)
+    return throw(ArgumentError("array type $bad is unsupported in batched_solve"))
+end
+
+"""
+    cuNumeric.batched_cholesky(A)
+
+Cholesky factor of every matrix in the stack `A`, returned as a single array of
+the same shape. Each `A[i, :, :]` is factored independently into a lower
+triangular `L` with `A[i, :, :] ≈ L * L'`; the upper triangle is zeroed.
+
+`A` must have shape `(b, m, m)`. As in `LinearAlgebra.cholesky`, only the lower
+triangle is read and Hermitian-ness is not checked.
+
+Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
+Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+"""
+function batched_cholesky(a::NDArray{<:_CHOLESKY_ACCEPTED,N}) where {N}
+    _assert_batched_dims(:batched_cholesky, N)
+    A = eltype(a)
+    O = _cholesky_eltype(A)
+    A <: _CHOLESKY_PROMOTABLE && assertpromotion(batched_cholesky, A, O)
+    return _cholesky(unchecked_promote_arr(a, O))
+end
+
+function batched_cholesky(a::NDArray)
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in batched_cholesky"))
+end
+
+"""
+    cuNumeric.batched_eigen(A) -> (values, vectors)
+
+Eigenvalues and right eigenvectors of every matrix in the stack `A`.
+
+`A` must have shape `(b, m, m)`. `values` has shape `(b, m)` and `vectors` has
+the shape of `A`, with `vectors[i, :, j]` the eigenvector for `values[i, j]`.
+
+Both results are always complex, even for real input. See `LinearAlgebra.eigen`.
+"""
+function batched_eigen(a::NDArray{<:_EIG_ACCEPTED,N}) where {N}
+    _assert_batched_dims(:batched_eigen, N)
+    return _eig(_promote_for_eig(a))
+end
+
+function batched_eigen(a::NDArray)
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in batched_eigen"))
+end
+
+"""
+    cuNumeric.batched_eigvals(A)
+
+Eigenvalues of every matrix in the stack `A`, as a complex array of shape
+`(b, m)`. See [`cuNumeric.batched_eigen`](@ref).
+"""
+function batched_eigvals(a::NDArray{<:_EIG_ACCEPTED,N}) where {N}
+    _assert_batched_dims(:batched_eigvals, N)
+    return _eigvals(_promote_for_eig(a))
+end
+
+function batched_eigvals(a::NDArray)
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in batched_eigvals"))
+end

--- a/src/ndarray/detail/linalg.jl
+++ b/src/ndarray/detail/linalg.jl
@@ -17,6 +17,12 @@ function choose_nd_color_shape(shape::NTuple{N,Int}) where {N}
     return Tuple(color_shape)
 end
 
+# One batch dimension is the ceiling for every batched op:
+#   - the POTRF task body is only instantiated for 2 <= DIM < 4
+#   - Legate.jl's `domain_from_shape` builds launch domains for at most three
+#     dimensions and yields an empty domain past that
+const MAX_BATCHED_DIM = 3
+
 function prepare_manual_task_for_batched_matrices(full_shape::NTuple{N,Int}) where {N}
     initial_color_shape = choose_nd_color_shape(full_shape)
     tilesize = Tuple(
@@ -45,6 +51,7 @@ function solve_batched(a::NDArray{T,N}, b::NDArray, x::NDArray) where {T,N}
         domain = Legate.domain_from_shape(Legate.Shape(Legate.to_cxx_vector(color_shape)))
         lib = cuNumeric.get_lib()
         task = Legate.create_manual_task(rt, lib, cuNumeric.SOLVE, domain)
+        cuNumeric.task_throws_exception(task, true)
 
         Legate.add_input(task, tiled_a)
         Legate.add_input(task, tiled_b)
@@ -61,17 +68,47 @@ const _SOLVE_ACCEPTED = Union{SUPPORTED_SOLVE_TYPES,_SOLVE_PROMOTABLE}
 _solve_eltype(::Type{T}) where {T<:_SOLVE_PROMOTABLE} = Float64
 _solve_eltype(::Type{T}) where {T<:SUPPORTED_SOLVE_TYPES} = T
 
-# `a` must be at least 2D, `b` at least 1D.
-function _solve_check_a_dims(a::NDArray{<:Any,0}, b::NDArray)
-    throw(ArgumentError("0-dimensional array given. Array must be at least two-dimensional"))
+# `a` must be at least 2D, `b` at least 1D. `solve` takes only the 2D case;
+# stacked systems go through `batched_solve`.
+function _solve_check_a_dims_2d(a::NDArray{<:Any,0}, b::NDArray)
+    return throw(ArgumentError("0-dimensional array given. Array must be two-dimensional"))
 end
-function _solve_check_a_dims(a::NDArray{<:Any,1}, b::NDArray)
-    throw(ArgumentError("1-dimensional array given. Array must be at least two-dimensional"))
+function _solve_check_a_dims_2d(a::NDArray{<:Any,1}, b::NDArray)
+    return throw(ArgumentError("1-dimensional array given. Array must be two-dimensional"))
 end
-_solve_check_a_dims(a::NDArray, b::NDArray) = _solve_check_b_dims(a, b)
+_solve_check_a_dims_2d(a::NDArray{<:Any,2}, b::NDArray) = _solve_check_b_dims(a, b)
+function _solve_check_a_dims_2d(a::NDArray{<:Any,N}, b::NDArray) where {N}
+    return throw(
+        ArgumentError(
+            "$N-dimensional array given. Use `cuNumeric.batched_solve` for " *
+            "stacked systems of shape (...,m,m)",
+        ),
+    )
+end
+
+function _solve_check_a_dims_batched(a::NDArray{<:Any,N}, b::NDArray) where {N}
+    _assert_batched_dims(:batched_solve, N)
+    return _solve_check_b_dims(a, b)
+end
+
+function _assert_batched_dims(f, N::Integer)
+    N < 3 && throw(
+        ArgumentError(
+            "$N-dimensional array given. `$f` requires shape (b,m,m); use the " *
+            "matching `LinearAlgebra` or `cuNumeric` function for a single matrix",
+        ),
+    )
+    N > MAX_BATCHED_DIM && throw(
+        ArgumentError(
+            "$N-dimensional array given. `$f` supports at most one batch " *
+            "dimension, i.e. shape (b,m,m)",
+        ),
+    )
+    return nothing
+end
 
 function _solve_check_b_dims(a::NDArray, b::NDArray{<:Any,0})
-    throw(ArgumentError("0-dimensional array given. Array must be at least one-dimensional"))
+    return throw(ArgumentError("0-dimensional array given. Array must be at least one-dimensional"))
 end
 _solve_check_b_dims(a::NDArray, b::NDArray) = _solve(a, b)
 
@@ -94,15 +131,101 @@ function _solve(a::NDArray{T,N}, b::NDArray{S,N}) where {T,S,N}
                 " (size $(size(b)[end-1]) is different from $(size(a)[end]))",
             ),
         )
-    prod(size(a)) == 0 || prod(size(b)) == 0 && return zeros(T, size(b)...)
-    x = zeros(T, size(b)...)
+    prod(size(a)) == 0 || prod(size(b)) == 0 && return cuNumeric.zeros(T, size(b)...)
+    x = cuNumeric.zeros(T, size(b)...)
     solve_batched(a, b, x)
     return x
 end
 
 # Mismatched batch dimensions
 function _solve(a::NDArray{T,N}, b::NDArray{S,M}) where {T,N,S,M}
-    throw(ArgumentError("Batched matrices require signature (...,m,m),(...,m,n)->(...,m,n)"))
+    return throw(ArgumentError("Batched matrices require signature (...,m,m),(...,m,n)->(...,m,n)"))
+end
+
+# cholesky
+
+"""
+    potrf!(out, a; lower, zeroout)
+
+Run the cupynumeric `POTRF` task, writing the Cholesky factor of `a` into `out`.
+
+The task is batched over the leading dimension: for a `(b, m, m)` input it
+factors each `m × m` block independently. `lower` selects which triangle holds
+the factor, `zeroout` zeros the opposite triangle in-task.
+"""
+function potrf!(out::NDArray{T,N}, a::NDArray{T,N}; lower::Bool, zeroout::Bool) where {T,N}
+    rt = Legate.get_runtime()
+    lib = cuNumeric.get_lib()
+
+    @task_scope "potrf" begin
+        task = Legate.create_auto_task(rt, lib, cuNumeric.POTRF)
+        cuNumeric.task_throws_exception(task, true)
+
+        l_a = nda_to_logical_array(a)
+        l_out = nda_to_logical_array(out)
+
+        in_var = Legate.add_input(task, l_a)
+        out_var = Legate.add_output(task, l_out)
+
+        Legate.add_scalar(task, Legate.Scalar(lower))
+        Legate.add_scalar(task, Legate.Scalar(zeroout))
+
+        # Each matrix must live on one processor; only the batch axes may split.
+        Legate.add_broadcast(task, l_a, CxxWrap.StdVector(UInt32[N - 2, N - 1]))
+        Legate.add_constraint(task, Legate.align(out_var, in_var))
+
+        Legate.submit_auto_task(rt, task)
+    end
+    return out
+end
+
+# eigen
+
+"""
+    geev!(a, ew, ev)
+
+Run the cupynumeric `GEEV` task, writing eigenvalues into `ew` and, unless `ev`
+is `nothing`, right eigenvectors into `ev` as columns.
+
+`ew` has one fewer dimension than `a`, so the launch domain maps onto it through
+a projection that drops the trailing axis. The task keys eigenvector computation
+off the number of registered outputs, so `ev` must not be added when only
+eigenvalues are wanted.
+"""
+function geev!(a::NDArray{T,N}, ew::NDArray, ev::Union{NDArray,Nothing}) where {T,N}
+    full_shape = size(a)
+    tilesize, color_shape = prepare_manual_task_for_batched_matrices(full_shape)
+
+    tiled_a = Legate.partition_by_tiling(nda_to_logical_store(a), collect(tilesize))
+    tiled_ew = Legate.partition_by_tiling(
+        nda_to_logical_store(ew), collect(tilesize[1:(end - 1)])
+    )
+    tiled_ev = if ev === nothing
+        nothing
+    else
+        Legate.partition_by_tiling(nda_to_logical_store(ev), collect(tilesize))
+    end
+
+    # 0-based source dimensions of the launch domain.
+    proj = CxxWrap.StdVector(Int32.(0:(N - 1)))
+    proj_ew = CxxWrap.StdVector(Int32.(0:(N - 2)))
+
+    @task_scope "geev" begin
+        rt = Legate.get_runtime()
+        domain = Legate.domain_from_shape(Legate.Shape(Legate.to_cxx_vector(color_shape)))
+        lib = cuNumeric.get_lib()
+        task = Legate.create_manual_task(rt, lib, cuNumeric.GEEV, domain)
+        cuNumeric.task_throws_exception(task, true)
+
+        cuNumeric.add_input_proj(task, tiled_a.handle, proj)
+        cuNumeric.add_output_proj(task, tiled_ew.handle, proj_ew)
+        if tiled_ev !== nothing
+            cuNumeric.add_output_proj(task, tiled_ev.handle, proj)
+        end
+
+        Legate.submit_manual_task(rt, task)
+    end
+    return nothing
 end
 
 function svd_single(a::NDArray{T,N}, u::NDArray, s::NDArray, vh::NDArray) where {T,N}
@@ -133,9 +256,9 @@ function _svd(a::NDArray{T,2}, full_matrices::Bool) where {T}
     k = min(m, n)
     S = real(T)
     # cuSolver requires full square buffers regardless of full_matrices
-    u_buf = zeros(T, m, m)
-    s = zeros(S, k)
-    vh_buf = zeros(T, n, n)
+    u_buf = cuNumeric.zeros(T, m, m)
+    s = cuNumeric.zeros(S, k)
+    vh_buf = cuNumeric.zeros(T, n, n)
     svd_single(a, u_buf, s, vh_buf)
     # Backend factors are logically ordered; only thin strided views need materialization.
     u = full_matrices ? u_buf : copy(u_buf[:, 1:k])
@@ -148,22 +271,6 @@ const _SVD_PROMOTABLE = Union{SUPPORTED_INT_TYPES,Bool}
 const _SVD_ACCEPTED = Union{SUPPORTED_SVD_TYPES,_SVD_PROMOTABLE}
 _svd_eltype(::Type{T}) where {T<:_SVD_PROMOTABLE} = Float64
 _svd_eltype(::Type{T}) where {T<:SUPPORTED_SVD_TYPES} = T
-
-function _svd_check_dims(a::NDArray{<:Any,0}, full_matrices::Bool)
-    throw(ArgumentError("0-dimensional array given. Array must be at least two-dimensional"))
-end
-
-function _svd_check_dims(a::NDArray{<:Any,1}, full_matrices::Bool)
-    throw(ArgumentError("1-dimensional array given. Array must be at least two-dimensional"))
-end
-
-function _svd_check_dims(a::NDArray{<:Any,2}, full_matrices::Bool)
-    return _svd(a, full_matrices)
-end
-
-function _svd_check_dims(a::NDArray, full_matrices::Bool)
-    throw(ArgumentError("cuNumeric does not yet support stacked 2d arrays"))
-end
 
 # qr
 
@@ -191,8 +298,8 @@ function _qr(a::NDArray{T,2}) where {T}
     m, n = size(a)
     k = min(m, n)
     # cuSolver requires full square buffers regardless of output shape
-    q_buf = zeros(T, m, m)
-    r_buf = zeros(T, n, n)
+    q_buf = cuNumeric.zeros(T, m, m)
+    r_buf = cuNumeric.zeros(T, n, n)
     qr_single(a, q_buf, r_buf)
     # Host conversion assumes contiguous storage, so materialize the economy slices.
     q = copy(q_buf[:, 1:k])
@@ -205,18 +312,87 @@ const _QR_ACCEPTED = Union{SUPPORTED_QR_TYPES,_QR_PROMOTABLE}
 _qr_eltype(::Type{T}) where {T<:_QR_PROMOTABLE} = Float64
 _qr_eltype(::Type{T}) where {T<:SUPPORTED_QR_TYPES} = T
 
-function _qr_check_dims(a::NDArray{<:Any,0})
-    throw(ArgumentError("0-dimensional array given. Array must be at least two-dimensional"))
+# cholesky/eigen guards. Both run in floating point only, so int/bool inputs
+# promote to Float64 the same way solve/svd/qr do.
+
+const _CHOLESKY_PROMOTABLE = Union{SUPPORTED_INT_TYPES,Bool}
+const _CHOLESKY_ACCEPTED = Union{SUPPORTED_CHOLESKY_TYPES,_CHOLESKY_PROMOTABLE}
+_cholesky_eltype(::Type{T}) where {T<:_CHOLESKY_PROMOTABLE} = Float64
+_cholesky_eltype(::Type{T}) where {T<:SUPPORTED_CHOLESKY_TYPES} = T
+
+const _EIG_PROMOTABLE = Union{SUPPORTED_INT_TYPES,Bool}
+const _EIG_ACCEPTED = Union{SUPPORTED_EIG_TYPES,_EIG_PROMOTABLE}
+_eig_eltype(::Type{T}) where {T<:_EIG_PROMOTABLE} = Float64
+_eig_eltype(::Type{T}) where {T<:SUPPORTED_EIG_TYPES} = T
+
+# GEEV always produces complex eigenvalues and eigenvectors, even for real input.
+_eig_complex_eltype(::Type{Float32}) = ComplexF32
+_eig_complex_eltype(::Type{ComplexF32}) = ComplexF32
+_eig_complex_eltype(::Type{Float64}) = ComplexF64
+_eig_complex_eltype(::Type{ComplexF64}) = ComplexF64
+
+function _check_square_matrices(f, a::NDArray{<:Any,N}) where {N}
+    N < 2 && throw(
+        ArgumentError(
+            "$N-dimensional array given. Array must be at least two-dimensional"
+        ),
+    )
+    sz = size(a)
+    sz[end - 1] != sz[end] &&
+        throw(ArgumentError("Last 2 dimensions of the array must be square in $f"))
+    sz[end] == 0 && throw(ArgumentError("Input shape dimension 0 not allowed in $f"))
+    return nothing
 end
 
-function _qr_check_dims(a::NDArray{<:Any,1})
-    throw(ArgumentError("1-dimensional array given. Array must be at least two-dimensional"))
+"""
+    _cholesky(a)
+
+Lower Cholesky factor of each trailing square block of `a`, with the upper
+triangle zeroed. Only the lower triangle of the input is read; the input is
+assumed Hermitian without being checked, matching cupynumeric.
+"""
+function _cholesky(a::NDArray{T,N}) where {T,N}
+    _check_square_matrices(:cholesky, a)
+    out = cuNumeric.zeros(T, size(a)...)
+    potrf!(out, a; lower=true, zeroout=true)
+    return out
 end
 
-function _qr_check_dims(a::NDArray{<:Any,2})
-    return _qr(a)
+"""
+    _eig(a)
+
+Eigenvalues and right eigenvectors of each trailing square block of `a`. Both
+are always complex.
+"""
+function _eig(a::NDArray{T,N}) where {T,N}
+    ew = _alloc_eigenvalues(a)
+    ev = cuNumeric.zeros(_eig_complex_eltype(T), size(a)...)
+    geev!(a, ew, ev)
+    return ew, ev
 end
 
-function _qr_check_dims(a::NDArray)
-    throw(ArgumentError("cuNumeric does not yet support stacked 2d arrays"))
+"""
+    _eigvals(a)
+
+Eigenvalues only. Registering just the one output is what tells the backend task
+to skip the eigenvector computation.
+"""
+function _eigvals(a::NDArray)
+    ew = _alloc_eigenvalues(a)
+    geev!(a, ew, nothing)
+    return ew
+end
+
+function _alloc_eigenvalues(a::NDArray{T,N}) where {T,N}
+    _check_square_matrices(:eigen, a)
+    _assert_geev_available()
+    return cuNumeric.zeros(_eig_complex_eltype(T), size(a)[1:(end - 1)]...)
+end
+
+function _assert_geev_available()
+    (Legate.num_gpus() > 0 && !cuNumeric.cusolver_has_geev()) && error(
+        "eigen requires cusolverDnXgeev, which the installed cuSolver does not " *
+        "provide. Upgrade CUDA (12.6.2 or newer) or run without GPUs.",
+    )
+    return nothing
 end

--- a/src/ndarray/linalg.jl
+++ b/src/ndarray/linalg.jl
@@ -1,15 +1,21 @@
+export NDArrayQR
+
 # Type/dim guards dispatch on one argument at a time, then forward to `_solve`.
 """
     cuNumeric.solve(A, b)
 
-Solve linear system(s) `A * x = b`.
+Solve the linear system `A * x = b`.
 
-`A` must have shape `(..., m, m)`. `b` must have shape `(..., m)` or `(..., m, n)`.
-The result has the same shape as `b`. Batch dimensions are supported; the
-implementation always uses the batched Legate `SOLVE` path.
+`A` must be a square `(m, m)` matrix. `b` must have shape `(m,)` or `(m, n)`.
+The result has the same shape as `b`.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
 Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+
+For a stack of systems of shape `(b, m, m)` use
+[`cuNumeric.batched_solve`](@ref).
+
+See also `\\`.
 """
 function solve(a::NDArray{<:_SOLVE_ACCEPTED}, b::NDArray{<:_SOLVE_ACCEPTED})
     A, B = eltype(a), eltype(b)
@@ -17,32 +23,183 @@ function solve(a::NDArray{<:_SOLVE_ACCEPTED}, b::NDArray{<:_SOLVE_ACCEPTED})
     # int/bool -> float is an implicit promotion, disallowed unless `allowpromotion`
     A <: _SOLVE_PROMOTABLE && assertpromotion(solve, A, O)
     B <: _SOLVE_PROMOTABLE && assertpromotion(solve, B, O)
-    return _solve_check_a_dims(unchecked_promote_arr(a, O), unchecked_promote_arr(b, O))
+    return _solve_check_a_dims_2d(unchecked_promote_arr(a, O), unchecked_promote_arr(b, O))
 end
 
 function solve(a::NDArray, b::NDArray)
     bad = eltype(a) <: _SOLVE_ACCEPTED ? eltype(b) : eltype(a)
-    throw(ArgumentError("array type $bad is unsupported in solve"))
+    return throw(ArgumentError("array type $bad is unsupported in solve"))
 end
 
-function svd(a::NDArray{<:_SVD_ACCEPTED}, full_matrices::Bool=true)
+"""
+    A \\ b
+
+Solve `A * x = b` for a square 2D `NDArray` `A`. Equivalent to
+[`cuNumeric.solve`](@ref).
+"""
+Base.:\(a::NDArray{<:Any,2}, b::NDArray{<:Any,1}) = solve(a, b)
+Base.:\(a::NDArray{<:Any,2}, b::NDArray{<:Any,2}) = solve(a, b)
+
+"""
+    LinearAlgebra.cholesky(A::NDArray{T,2}) -> Cholesky
+
+Cholesky factorization of the Hermitian positive-definite matrix `A`, returned as
+a `LinearAlgebra.Cholesky` object holding the lower factor `L` with `A ≈ L * L'`.
+
+Only the lower triangle of `A` is read and, unlike Base, it is *not* checked for
+being Hermitian. A non-positive-definite input raises an `ErrorException` from
+the task rather than `LinearAlgebra.PosDefException`, so the `check` keyword is
+not supported.
+
+Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
+Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+
+For a stack of matrices of shape `(b, m, m)` use
+[`cuNumeric.batched_cholesky`](@ref).
+"""
+function LinearAlgebra.cholesky(a::NDArray{<:_CHOLESKY_ACCEPTED,2})
+    return LinearAlgebra.Cholesky(_promoted_cholesky(a), 'L', 0)
+end
+
+function LinearAlgebra.cholesky(a::NDArray{<:Any,2})
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in cholesky"))
+end
+
+function _promoted_cholesky(a::NDArray)
+    A = eltype(a)
+    O = _cholesky_eltype(A)
+    A <: _CHOLESKY_PROMOTABLE && assertpromotion(cholesky, A, O)
+    return _cholesky(unchecked_promote_arr(a, O))
+end
+
+"""
+    LinearAlgebra.eigen(A::NDArray{T,2}) -> Eigen
+
+Eigenvalues and right eigenvectors of the square matrix `A`, returned as a
+`LinearAlgebra.Eigen` object. Column `j` of `F.vectors` is the eigenvector for
+`F.values[j]`.
+
+Values and vectors are **always complex**, even when `A` is real with real
+eigenvalues. This follows the underlying LAPACK `geev` path and differs from
+Base, which returns real factors for such input.
+
+Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
+Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+
+For a stack of matrices of shape `(b, m, m)` use
+[`cuNumeric.batched_eigen`](@ref).
+"""
+function LinearAlgebra.eigen(a::NDArray{<:_EIG_ACCEPTED,2})
+    return LinearAlgebra.Eigen(_eig(_promote_for_eig(a))...)
+end
+
+function LinearAlgebra.eigen(a::NDArray{<:Any,2})
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in eigen"))
+end
+
+"""
+    LinearAlgebra.eigvals(A::NDArray{T,2})
+
+Eigenvalues of the square matrix `A` as a complex `NDArray`. See
+`LinearAlgebra.eigen` for the supported element types and for why the
+result is always complex.
+"""
+LinearAlgebra.eigvals(a::NDArray{<:_EIG_ACCEPTED,2}) = _eigvals(_promote_for_eig(a))
+
+function LinearAlgebra.eigvals(a::NDArray{<:Any,2})
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in eigvals"))
+end
+
+"""
+    LinearAlgebra.eigvecs(A::NDArray{T,2})
+
+Right eigenvectors of the square matrix `A`, as columns of a complex `NDArray`.
+See `LinearAlgebra.eigen` for the supported element types.
+"""
+LinearAlgebra.eigvecs(a::NDArray{<:Any,2}) = LinearAlgebra.eigen(a).vectors
+
+function _promote_for_eig(a::NDArray)
+    A = eltype(a)
+    O = _eig_eltype(A)
+    A <: _EIG_PROMOTABLE && assertpromotion(eigen, A, O)
+    return unchecked_promote_arr(a, O)
+end
+
+"""
+    LinearAlgebra.svd(A::NDArray{T,2}; full=false) -> SVD
+
+Singular value decomposition of `A`, returned as a `LinearAlgebra.SVD` object
+with `A ≈ F.U * Diagonal(F.S) * F.Vt`.
+
+With `m, n = size(A)` and `k = min(m, n)`, `full=false` gives an `m × k` `F.U`
+and a `k × n` `F.Vt`, and `full=true` gives `m × m` and `n × n`. `F.S` has length
+`k` and is real-valued for both real and complex input.
+
+Destructuring an `SVD` yields `(U, S, V)` — the adjoint of `F.Vt`, not `F.Vt`
+itself. `F.V` is a lazy `Adjoint` wrapper, so operating on it falls back to
+scalar indexing until `adjoint(::NDArray)` is implemented; prefer `F.Vt`.
+
+Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
+Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+"""
+function LinearAlgebra.svd(a::NDArray{<:_SVD_ACCEPTED,2}; full::Bool=false)
     A = eltype(a)
     O = _svd_eltype(A)
     A <: _SVD_PROMOTABLE && assertpromotion(svd, A, O)
-    return _svd_check_dims(unchecked_promote_arr(a, O), full_matrices)
+    return LinearAlgebra.SVD(_svd(unchecked_promote_arr(a, O), full)...)
 end
 
-function svd(a::NDArray, full_matrices::Bool=true)
-    throw(ArgumentError("array type $(eltype(a)) is unsupported in svd"))
+function LinearAlgebra.svd(a::NDArray{<:Any,2}; full::Bool=false)
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in svd"))
 end
 
-function qr(a::NDArray{<:_QR_ACCEPTED})
+"""
+    NDArrayQR <: LinearAlgebra.Factorization
+
+QR factorization of an `NDArray`, holding the explicit factors `Q` and `R` with
+`A ≈ Q * R`.
+
+The backend returns materialized factors rather than the packed Householder
+representation Base uses, so this is a distinct type from `LinearAlgebra.QR` and
+`QRCompactWY`. It destructures as `(Q, R)` and exposes `F.Q` and `F.R`.
+"""
+struct NDArrayQR{T,M<:NDArray{T,2}} <: LinearAlgebra.Factorization{T}
+    Q::M
+    R::M
+end
+
+Base.iterate(F::NDArrayQR) = (F.Q, Val(:R))
+Base.iterate(F::NDArrayQR, ::Val{:R}) = (F.R, Val(:done))
+Base.iterate(::NDArrayQR, ::Val{:done}) = nothing
+Base.size(F::NDArrayQR) = (size(F.Q, 1), size(F.R, 2))
+Base.size(F::NDArrayQR, d::Integer) = d == 1 ? size(F.Q, 1) : size(F.R, d)
+
+function Base.show(io::IO, ::MIME"text/plain", F::NDArrayQR)
+    summary(io, F)
+    println(io)
+    println(io, "Q factor: ", summary(F.Q))
+    print(io, "R factor: ", summary(F.R))
+    return nothing
+end
+
+"""
+    LinearAlgebra.qr(A::NDArray{T,2}) -> NDArrayQR
+
+Reduced QR factorization of `A`, with `A ≈ F.Q * F.R`. For an `m × n` input and
+`k = min(m, n)`, `F.Q` is `m × k` and `F.R` is `k × n`.
+
+See [`NDArrayQR`](@ref) for why this is not a `LinearAlgebra.QRCompactWY`.
+
+Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
+Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+"""
+function LinearAlgebra.qr(a::NDArray{<:_QR_ACCEPTED,2})
     A = eltype(a)
     O = _qr_eltype(A)
     A <: _QR_PROMOTABLE && assertpromotion(qr, A, O)
-    return _qr_check_dims(unchecked_promote_arr(a, O))
+    return NDArrayQR(_qr(unchecked_promote_arr(a, O))...)
 end
 
-function qr(a::NDArray)
-    throw(ArgumentError("array type $(eltype(a)) is unsupported in qr"))
+function LinearAlgebra.qr(a::NDArray{<:Any,2})
+    return throw(ArgumentError("array type $(eltype(a)) is unsupported in qr"))
 end

--- a/src/ndarray/linalg.jl
+++ b/src/ndarray/linalg.jl
@@ -10,20 +10,20 @@ Solve the linear system `A * x = b`.
 The result has the same shape as `b`.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 
 For a stack of systems of shape `(b, m, m)` use
 [`cuNumeric.batched_solve`](@ref).
 
 See also `\\`.
 """
-function solve(a::NDArray{<:_SOLVE_ACCEPTED}, b::NDArray{<:_SOLVE_ACCEPTED})
-    A, B = eltype(a), eltype(b)
+function solve(a::NDArray{A}, b::NDArray{B}) where {A<:_SOLVE_ACCEPTED,B<:_SOLVE_ACCEPTED}
     O = promote_type(_solve_eltype(A), _solve_eltype(B))
-    # int/bool -> float is an implicit promotion, disallowed unless `allowpromotion`
-    A <: _SOLVE_PROMOTABLE && assertpromotion(solve, A, O)
-    B <: _SOLVE_PROMOTABLE && assertpromotion(solve, B, O)
-    return _solve_check_a_dims_2d(unchecked_promote_arr(a, O), unchecked_promote_arr(b, O))
+    return _solve_check_a_dims_2d(
+        checked_promote_arr(solve, a, O), checked_promote_arr(solve, b, O)
+    )
 end
 
 function solve(a::NDArray, b::NDArray)
@@ -52,24 +52,20 @@ the task rather than `LinearAlgebra.PosDefException`, so the `check` keyword is
 not supported.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 
 For a stack of matrices of shape `(b, m, m)` use
 [`cuNumeric.batched_cholesky`](@ref).
 """
-function LinearAlgebra.cholesky(a::NDArray{<:_CHOLESKY_ACCEPTED,2})
-    return LinearAlgebra.Cholesky(_promoted_cholesky(a), 'L', 0)
+function LinearAlgebra.cholesky(a::NDArray{T,2}) where {T<:_CHOLESKY_ACCEPTED}
+    factors = _cholesky(checked_promote_arr(cholesky, a, _cholesky_eltype(T)))
+    return LinearAlgebra.Cholesky(factors, 'L', 0)
 end
 
 function LinearAlgebra.cholesky(a::NDArray{<:Any,2})
     return throw(ArgumentError("array type $(eltype(a)) is unsupported in cholesky"))
-end
-
-function _promoted_cholesky(a::NDArray)
-    A = eltype(a)
-    O = _cholesky_eltype(A)
-    A <: _CHOLESKY_PROMOTABLE && assertpromotion(cholesky, A, O)
-    return _cholesky(unchecked_promote_arr(a, O))
 end
 
 """
@@ -84,13 +80,15 @@ eigenvalues. This follows the underlying LAPACK `geev` path and differs from
 Base, which returns real factors for such input.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 
 For a stack of matrices of shape `(b, m, m)` use
 [`cuNumeric.batched_eigen`](@ref).
 """
-function LinearAlgebra.eigen(a::NDArray{<:_EIG_ACCEPTED,2})
-    return LinearAlgebra.Eigen(_eig(_promote_for_eig(a))...)
+function LinearAlgebra.eigen(a::NDArray{T,2}) where {T<:_EIG_ACCEPTED}
+    return LinearAlgebra.Eigen(_eig(checked_promote_arr(eigen, a, _eig_eltype(T)))...)
 end
 
 function LinearAlgebra.eigen(a::NDArray{<:Any,2})
@@ -104,7 +102,9 @@ Eigenvalues of the square matrix `A` as a complex `NDArray`. See
 `LinearAlgebra.eigen` for the supported element types and for why the
 result is always complex.
 """
-LinearAlgebra.eigvals(a::NDArray{<:_EIG_ACCEPTED,2}) = _eigvals(_promote_for_eig(a))
+function LinearAlgebra.eigvals(a::NDArray{T,2}) where {T<:_EIG_ACCEPTED}
+    return _eigvals(checked_promote_arr(eigvals, a, _eig_eltype(T)))
+end
 
 function LinearAlgebra.eigvals(a::NDArray{<:Any,2})
     return throw(ArgumentError("array type $(eltype(a)) is unsupported in eigvals"))
@@ -117,13 +117,6 @@ Right eigenvectors of the square matrix `A`, as columns of a complex `NDArray`.
 See `LinearAlgebra.eigen` for the supported element types.
 """
 LinearAlgebra.eigvecs(a::NDArray{<:Any,2}) = LinearAlgebra.eigen(a).vectors
-
-function _promote_for_eig(a::NDArray)
-    A = eltype(a)
-    O = _eig_eltype(A)
-    A <: _EIG_PROMOTABLE && assertpromotion(eigen, A, O)
-    return unchecked_promote_arr(a, O)
-end
 
 """
     LinearAlgebra.svd(A::NDArray{T,2}; full=false) -> SVD
@@ -140,13 +133,12 @@ itself. `F.V` is a lazy `Adjoint` wrapper, so operating on it falls back to
 scalar indexing until `adjoint(::NDArray)` is implemented; prefer `F.Vt`.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 """
-function LinearAlgebra.svd(a::NDArray{<:_SVD_ACCEPTED,2}; full::Bool=false)
-    A = eltype(a)
-    O = _svd_eltype(A)
-    A <: _SVD_PROMOTABLE && assertpromotion(svd, A, O)
-    return LinearAlgebra.SVD(_svd(unchecked_promote_arr(a, O), full)...)
+function LinearAlgebra.svd(a::NDArray{T,2}; full::Bool=false) where {T<:_SVD_ACCEPTED}
+    return LinearAlgebra.SVD(_svd(checked_promote_arr(svd, a, _svd_eltype(T)), full)...)
 end
 
 function LinearAlgebra.svd(a::NDArray{<:Any,2}; full::Bool=false)
@@ -191,13 +183,12 @@ Reduced QR factorization of `A`, with `A ≈ F.Q * F.R`. For an `m × n` input a
 See [`NDArrayQR`](@ref) for why this is not a `LinearAlgebra.QRCompactWY`.
 
 Accepted element types are `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`.
-Integer or `Bool` inputs promote to `Float64` only when promotion is allowed.
+Integer and `Bool` inputs are converted to `Float64`. As everywhere else in
+the package, that conversion needs `@allowpromotion` only when it widens the
+element type, so `Int64` and `UInt64` pass through silently.
 """
-function LinearAlgebra.qr(a::NDArray{<:_QR_ACCEPTED,2})
-    A = eltype(a)
-    O = _qr_eltype(A)
-    A <: _QR_PROMOTABLE && assertpromotion(qr, A, O)
-    return NDArrayQR(_qr(unchecked_promote_arr(a, O))...)
+function LinearAlgebra.qr(a::NDArray{T,2}) where {T<:_QR_ACCEPTED}
+    return NDArrayQR(_qr(checked_promote_arr(qr, a, _qr_eltype(T)))...)
 end
 
 function LinearAlgebra.qr(a::NDArray{<:Any,2})

--- a/src/ndarray/promotion.jl
+++ b/src/ndarray/promotion.jl
@@ -5,7 +5,15 @@ is_wider_type(::Type{A}, ::Type{B}) where {A,B} = sizeof(A) > sizeof(B)
 checked_promote_arr(arr::NDArray{T}, ::Type{T}) where {T} = arr
 
 function checked_promote_arr(arr::NDArray{T}, ::Type{S}) where {T,S}
-    is_wider_type(S, T) && assertpromotion(promote_type, T, S)
+    return checked_promote_arr(promote_type, arr, S)
+end
+
+# `op` only names the caller in the error message, so that e.g. cholesky reports
+# itself rather than `promote_type`.
+checked_promote_arr(op, arr::NDArray{T}, ::Type{T}) where {T} = arr
+
+function checked_promote_arr(op, arr::NDArray{T}, ::Type{S}) where {T,S}
+    is_wider_type(S, T) && assertpromotion(op, T, S)
     return as_type(arr, S)
 end
 

--- a/test/analysis/type_stability.jl
+++ b/test/analysis/type_stability.jl
@@ -127,14 +127,14 @@ end
 @testset verbose = true "svd" begin
     @testset "$(T)" for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         A = cuNumeric.NDArray(T[1 0; 0 1])
-        @test @inferred(cuNumeric.svd(A)) !== nothing
-        @test @inferred(cuNumeric.svd(A, false)) !== nothing
+        @test @inferred(LinearAlgebra.svd(A)) !== nothing
+        @test @inferred(LinearAlgebra.svd(A; full=true)) !== nothing
     end
 
     @testset "promote $(T)" for T in (Int32, Int64, Bool)
         A = cuNumeric.NDArray(T[1 0; 0 1])
         allowpromotion() do
-            @test @inferred(cuNumeric.svd(A)) !== nothing
+            @test @inferred(LinearAlgebra.svd(A)) !== nothing
         end
     end
 end
@@ -142,14 +142,56 @@ end
 @testset verbose = true "qr" begin
     @testset "$(T)" for T in Base.uniontypes(cuNumeric.SUPPORTED_QR_TYPES)
         A = cuNumeric.NDArray(T[1 0; 0 1])
-        @test @inferred(cuNumeric.qr(A)) !== nothing
+        @test @inferred(LinearAlgebra.qr(A)) !== nothing
     end
 
     @testset "promote $(T)" for T in (Int32, Int64, Bool)
         A = cuNumeric.NDArray(T[1 0; 0 1])
         allowpromotion() do
-            @test @inferred(cuNumeric.qr(A)) !== nothing
+            @test @inferred(LinearAlgebra.qr(A)) !== nothing
         end
+    end
+end
+
+@testset verbose = true "cholesky" begin
+    @testset "$(T)" for T in Base.uniontypes(cuNumeric.SUPPORTED_CHOLESKY_TYPES)
+        A = cuNumeric.NDArray(Matrix{T}(I, 2, 2))
+        @test @inferred(LinearAlgebra.cholesky(A)) !== nothing
+        B = cuNumeric.NDArray(reshape(Matrix{T}(I, 2, 2), 1, 2, 2))
+        @test @inferred(cuNumeric.batched_cholesky(B)) !== nothing
+    end
+
+    @testset "promote $(T)" for T in (Int32, Int64, Bool)
+        A = cuNumeric.NDArray(T[1 0; 0 1])
+        allowpromotion() do
+            @test @inferred(LinearAlgebra.cholesky(A)) !== nothing
+        end
+    end
+end
+
+@testset verbose = true "eigen" begin
+    @testset "$(T)" for T in Base.uniontypes(cuNumeric.SUPPORTED_EIG_TYPES)
+        A = cuNumeric.NDArray(Matrix{T}(I, 2, 2))
+        @test @inferred(LinearAlgebra.eigen(A)) !== nothing
+        @test @inferred(LinearAlgebra.eigvals(A)) !== nothing
+        B = cuNumeric.NDArray(reshape(Matrix{T}(I, 2, 2), 1, 2, 2))
+        @test @inferred(cuNumeric.batched_eigen(B)) !== nothing
+        @test @inferred(cuNumeric.batched_eigvals(B)) !== nothing
+    end
+
+    @testset "promote $(T)" for T in (Int32, Int64, Bool)
+        A = cuNumeric.NDArray(T[1 0; 0 1])
+        allowpromotion() do
+            @test @inferred(LinearAlgebra.eigen(A)) !== nothing
+        end
+    end
+end
+
+@testset verbose = true "batched_solve" begin
+    @testset "$(T)" for T in Base.uniontypes(cuNumeric.SUPPORTED_SOLVE_TYPES)
+        A = cuNumeric.NDArray(reshape(T[2 1; 5 7], 1, 2, 2))
+        b = cuNumeric.NDArray(reshape(T[11, 13], 1, 2, 1))
+        @test @inferred(cuNumeric.batched_solve(A, b)) !== nothing
     end
 end
 

--- a/test/array/batched_linalg.jl
+++ b/test/array/batched_linalg.jl
@@ -61,7 +61,11 @@ end
         A = cuNumeric.NDArray(reshape(T[1, 0, 0, 1], 1, 2, 2))
         b = cuNumeric.NDArray(reshape(T[1, 1], 1, 2, 1))
 
-        @test_throws "Implicit promotion" cuNumeric.batched_solve(A, b)
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" cuNumeric.batched_solve(A, b)
+        else
+            @test cuNumeric.batched_solve(A, b) isa NDArray{Float64}
+        end
 
         allowpromotion() do
             x = cuNumeric.batched_solve(A, b)
@@ -102,7 +106,11 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = reshape(T[1, 0, 0, 1], 1, 2, 2)
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" cuNumeric.batched_cholesky(A)
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" cuNumeric.batched_cholesky(A)
+        else
+            @test cuNumeric.batched_cholesky(A) isa NDArray{Float64}
+        end
         allowpromotion() do
             out = cuNumeric.batched_cholesky(A)
             allowscalar() do

--- a/test/array/batched_linalg.jl
+++ b/test/array/batched_linalg.jl
@@ -1,0 +1,182 @@
+#= Copyright 2026 Northwestern University,
+ *                   Carnegie Mellon University University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author(s): Ethan Meitz <emeitz@andrew.cmu.edu>
+=#
+
+# Batched (3D+) linear algebra. These entry points are deliberately not
+# LinearAlgebra methods: Base has no batched equivalent.
+
+const N_BATCH = 3
+
+function batched_spd(::Type{T}, b, n) where {T}
+    RT = real(T)
+    out = zeros(T, b, n, n)
+    for i in 1:b
+        B = my_rand(T, n, n; L=RT(-1), R=RT(1))
+        out[i, :, :] = B * B' + T(n) * Matrix{T}(I, n, n)
+    end
+    return out
+end
+
+function batched_random(::Type{T}, dims...) where {T}
+    RT = real(T)
+    return my_rand(T, dims...; L=RT(-1), R=RT(1))
+end
+
+@testset "batched_solve" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SOLVE_TYPES)
+        n, nrhs = 4, 2
+        A_ref = batched_spd(T, N_BATCH, n)
+        b_ref = batched_random(T, N_BATCH, n, nrhs)
+
+        x = cuNumeric.batched_solve(cuNumeric.NDArray(A_ref), cuNumeric.NDArray(b_ref))
+
+        allowscalar() do
+            X = Array(x)
+            @test size(X) == (N_BATCH, n, nrhs)
+            for i in 1:N_BATCH
+                @test isapprox(
+                    A_ref[i, :, :] \ b_ref[i, :, :], X[i, :, :]; atol=atol(T), rtol=rtol(T)
+                )
+            end
+        end
+    end
+end
+
+@testset "batched_solve promotion" begin
+    @testset verbose=true for T in (Int32, Int64, Bool)
+        A = cuNumeric.NDArray(reshape(T[1, 0, 0, 1], 1, 2, 2))
+        b = cuNumeric.NDArray(reshape(T[1, 1], 1, 2, 1))
+
+        @test_throws "Implicit promotion" cuNumeric.batched_solve(A, b)
+
+        allowpromotion() do
+            x = cuNumeric.batched_solve(A, b)
+            allowscalar() do
+                @test safe_compare(
+                    reshape(Float64[1, 1], 1, 2, 1), x, atol(Float64), rtol(Float64)
+                )
+            end
+        end
+    end
+end
+
+@testset "batched_solve rejects 2D input" begin
+    A = cuNumeric.zeros(Float64, 3, 3)
+    b = cuNumeric.zeros(Float64, 3, 1)
+    @test_throws "requires shape (b,m,m)" cuNumeric.batched_solve(A, b)
+end
+
+@testset "batched_cholesky" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_CHOLESKY_TYPES)
+        n = 4
+        A_ref = batched_spd(T, N_BATCH, n)
+        out = cuNumeric.batched_cholesky(cuNumeric.NDArray(A_ref))
+
+        allowscalar() do
+            L = Array(out)
+            @test size(L) == (N_BATCH, n, n)
+            for i in 1:N_BATCH
+                Li = L[i, :, :]
+                @test istril(Li)
+                @test isapprox(A_ref[i, :, :], Li * Li'; atol=atol(T), rtol=rtol(T))
+            end
+        end
+    end
+end
+
+@testset "batched_cholesky promotion" begin
+    @testset verbose=true for T in (Int32, Int64, Bool)
+        vals = reshape(T[1, 0, 0, 1], 1, 2, 2)
+        A = cuNumeric.NDArray(vals)
+        @test_throws "Implicit promotion" cuNumeric.batched_cholesky(A)
+        allowpromotion() do
+            out = cuNumeric.batched_cholesky(A)
+            allowscalar() do
+                @test safe_compare(Float64.(vals), out, atol(Float64), rtol(Float64))
+            end
+        end
+    end
+end
+
+function batched_eigen_residual(A_ref, values, vectors, i)
+    C = eltype(values)
+    Ai = C.(A_ref[i, :, :])
+    Vi = vectors[i, :, :]
+    return maximum(abs.(Ai * Vi .- Vi * Diagonal(values[i, :])))
+end
+
+@testset "batched_eigen" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_EIG_TYPES)
+        n = 4
+        A_ref = batched_random(T, N_BATCH, n, n)
+        values, vectors = cuNumeric.batched_eigen(cuNumeric.NDArray(A_ref))
+
+        allowscalar() do
+            vals, vecs = Array(values), Array(vectors)
+            @test size(vals) == (N_BATCH, n)
+            @test size(vecs) == (N_BATCH, n, n)
+            @test eltype(vals) == complex(T)
+            for i in 1:N_BATCH
+                @test batched_eigen_residual(A_ref, vals, vecs, i) <=
+                    max(atol(T), rtol(T) * n)
+                @test isapprox(
+                    sort(vals[i, :]; by=x -> (real(x), imag(x))),
+                    sort(LinearAlgebra.eigvals(A_ref[i, :, :]); by=x -> (real(x), imag(x))),
+                    atol=atol(T),
+                    rtol=rtol(T),
+                )
+            end
+        end
+    end
+end
+
+@testset "batched_eigvals" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_EIG_TYPES)
+        n = 4
+        A_ref = batched_random(T, N_BATCH, n, n)
+        values = cuNumeric.batched_eigvals(cuNumeric.NDArray(A_ref))
+
+        allowscalar() do
+            vals = Array(values)
+            @test size(vals) == (N_BATCH, n)
+            for i in 1:N_BATCH
+                @test isapprox(
+                    sort(vals[i, :]; by=x -> (real(x), imag(x))),
+                    sort(LinearAlgebra.eigvals(A_ref[i, :, :]); by=x -> (real(x), imag(x))),
+                    atol=atol(T),
+                    rtol=rtol(T),
+                )
+            end
+        end
+    end
+end
+
+@testset "batched dimension limits" begin
+    # Exactly one batch dimension: 2D belongs to the LinearAlgebra entry points,
+    # and 4D exceeds both the POTRF task and Legate's launch-domain construction.
+    @testset "$f" for f in
+                      (cuNumeric.batched_cholesky, cuNumeric.batched_eigen,
+        cuNumeric.batched_eigvals)
+        @test_throws ArgumentError f(cuNumeric.zeros(Float64, 3, 3))
+        @test_throws ArgumentError f(cuNumeric.zeros(Float64, 2, 2, 3, 3))
+        @test_throws ArgumentError f(cuNumeric.zeros(Float64, 2, 3, 4))
+    end
+
+    @test_throws ArgumentError cuNumeric.batched_solve(
+        cuNumeric.zeros(Float64, 2, 2, 3, 3), cuNumeric.zeros(Float64, 2, 2, 3, 1)
+    )
+end

--- a/test/array/linalg.jl
+++ b/test/array/linalg.jl
@@ -247,8 +247,12 @@ end
         A = cuNumeric.NDArray(T[1 0; 0 1])
         b = cuNumeric.NDArray(reshape(T[1, 1], 2, 1))
 
-        # int/bool requires promotion to float. Will throw without allowpromtion()
-        @test_throws "Implicit promotion" cuNumeric.solve(A, b)
+        # int/bool converts to float; only a widening conversion needs allowpromotion()
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" cuNumeric.solve(A, b)
+        else
+            @test cuNumeric.solve(A, b) isa NDArray{Float64}
+        end
 
         # ...allowed under @allowpromotion, result is Float64
         allowpromotion() do
@@ -392,7 +396,11 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = T == Bool ? T[1 0; 0 1] : reshape(T.(collect(1:4)), 2, 2)
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" LinearAlgebra.svd(A)
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" LinearAlgebra.svd(A)
+        else
+            @test LinearAlgebra.svd(A) isa LinearAlgebra.SVD
+        end
         allowpromotion() do
             F = LinearAlgebra.svd(A)
             @test eltype(Array(F.U)) == Float64
@@ -433,7 +441,11 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = T == Bool ? T[1 0; 0 1] : reshape(T.(collect(1:4)), 2, 2)
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" LinearAlgebra.qr(A)
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" LinearAlgebra.qr(A)
+        else
+            @test LinearAlgebra.qr(A) isa cuNumeric.NDArrayQR
+        end
         allowpromotion() do
             q, r = LinearAlgebra.qr(A)
             allowscalar() do
@@ -543,7 +555,11 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = T == Bool ? T[1 0; 0 1] : T[2 0; 0 2]
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" LinearAlgebra.cholesky(A)
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" LinearAlgebra.cholesky(A)
+        else
+            @test LinearAlgebra.cholesky(A) isa LinearAlgebra.Cholesky
+        end
         allowpromotion() do
             F = LinearAlgebra.cholesky(A)
             allowscalar() do
@@ -645,7 +661,11 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = T == Bool ? T[1 0; 0 1] : T[2 0; 0 3]
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" LinearAlgebra.eigen(A)
+        if promotion_is_gated(T, Float64)
+            @test_throws "Implicit promotion" LinearAlgebra.eigen(A)
+        else
+            @test LinearAlgebra.eigen(A) isa LinearAlgebra.Eigen
+        end
         allowpromotion() do
             F = LinearAlgebra.eigen(A)
             allowscalar() do

--- a/test/array/linalg.jl
+++ b/test/array/linalg.jl
@@ -261,32 +261,51 @@ end
     end
 end
 
-function check_svd_reconstruction(ref_A::AbstractMatrix, u, s, vh, tol_a, tol_r)
-    U = Array(u)
-    S = Array(s)
-    Vh = Array(vh)
-    A_rec = U * Diagonal(S) * Vh
+@testset "solve rejects batched input" begin
+    A = cuNumeric.zeros(Float64, 2, 3, 3)
+    b = cuNumeric.zeros(Float64, 2, 3, 1)
+    @test_throws "batched_solve" cuNumeric.solve(A, b)
+end
+
+@testset "backslash" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SOLVE_TYPES)
+        A_ref = T[2 1; 5 7]
+        b_ref = T[11, 13]
+        A = cuNumeric.NDArray(A_ref)
+
+        x_vec = A \ cuNumeric.NDArray(b_ref)
+        x_mat = A \ cuNumeric.NDArray(reshape(b_ref, 2, 1))
+
+        allowscalar() do
+            @test safe_compare(A_ref \ b_ref, x_vec, atol(T), rtol(T))
+            @test safe_compare(A_ref \ reshape(b_ref, 2, 1), x_mat, atol(T), rtol(T))
+        end
+    end
+end
+
+function check_svd_reconstruction(ref_A::AbstractMatrix, F, tol_a, tol_r)
+    A_rec = Array(F.U) * Diagonal(Array(F.S)) * Array(F.Vt)
     return isapprox(ref_A, A_rec; atol=tol_a, rtol=tol_r)
 end
 
-function check_svd_orthonormality(u, vh, tol_a, tol_r)
-    U = Array(u)
-    Vh = Array(vh)
+function check_svd_orthonormality(F, tol_a, tol_r)
+    U = Array(F.U)
+    Vt = Array(F.Vt)
     ku = size(U, 2)
-    kv = size(Vh, 1)
+    kv = size(Vt, 1)
     ok_u = isapprox(U' * U, Matrix{eltype(U)}(I, ku, ku); atol=tol_a, rtol=tol_r)
-    ok_vh = isapprox(Vh * Vh', Matrix{eltype(Vh)}(I, kv, kv); atol=tol_a, rtol=tol_r)
-    return ok_u && ok_vh
+    ok_vt = isapprox(Vt * Vt', Matrix{eltype(Vt)}(I, kv, kv); atol=tol_a, rtol=tol_r)
+    return ok_u && ok_vt
 end
 
 @testset "svd square matrix" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         A_ref = my_rand(T, 5, 5)
-        nda = cuNumeric.NDArray(A_ref)
-        u, s, vh = cuNumeric.svd(nda)
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref))
+        @test F isa LinearAlgebra.SVD
         allowscalar() do
-            @test check_svd_reconstruction(A_ref, u, s, vh, atol(T), rtol(T))
-            @test check_svd_orthonormality(u, vh, atol(T), rtol(T))
+            @test check_svd_reconstruction(A_ref, F, atol(T), rtol(T))
+            @test check_svd_orthonormality(F, atol(T), rtol(T))
         end
     end
 end
@@ -294,41 +313,38 @@ end
 @testset "svd tall matrix (m > n)" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         A_ref = my_rand(T, 6, 4)
-        nda = cuNumeric.NDArray(A_ref)
-        u, s, vh = cuNumeric.svd(nda, false)  # thin SVD for reconstruction test
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref))  # thin, for reconstruction
         allowscalar() do
-            @test check_svd_reconstruction(A_ref, u, s, vh, atol(T), rtol(T))
-            @test check_svd_orthonormality(u, vh, atol(T), rtol(T))
+            @test check_svd_reconstruction(A_ref, F, atol(T), rtol(T))
+            @test check_svd_orthonormality(F, atol(T), rtol(T))
         end
     end
 end
 
-@testset "svd thin output shapes (full_matrices=false)" begin
+@testset "svd thin output shapes (full=false)" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         m, n = 6, 4
         k = min(m, n)
         A_ref = my_rand(T, m, n)
-        nda = cuNumeric.NDArray(A_ref)
-        u, s, vh = cuNumeric.svd(nda, false)
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref))
         allowscalar() do
-            @test size(Array(u)) == (m, k)
-            @test size(Array(s)) == (k,)
-            @test size(Array(vh)) == (k, n)
-            @test check_svd_reconstruction(A_ref, u, s, vh, atol(T), rtol(T))
+            @test size(Array(F.U)) == (m, k)
+            @test size(Array(F.S)) == (k,)
+            @test size(Array(F.Vt)) == (k, n)
+            @test check_svd_reconstruction(A_ref, F, atol(T), rtol(T))
         end
     end
 end
 
-@testset "svd full output shapes (full_matrices=true)" begin
+@testset "svd full output shapes (full=true)" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         m, n = 6, 4
         A_ref = my_rand(T, m, n)
-        nda = cuNumeric.NDArray(A_ref)
-        u, s, vh = cuNumeric.svd(nda, true)
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref); full=true)
         allowscalar() do
-            @test size(Array(u)) == (m, m)
-            @test size(Array(s)) == (min(m, n),)
-            @test size(Array(vh)) == (n, n)
+            @test size(Array(F.U)) == (m, m)
+            @test size(Array(F.S)) == (min(m, n),)
+            @test size(Array(F.Vt)) == (n, n)
         end
     end
 end
@@ -336,10 +352,9 @@ end
 @testset "svd singular values non-negative and sorted" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         A_ref = my_rand(T, 5, 5)
-        nda = cuNumeric.NDArray(A_ref)
-        _, s, _ = cuNumeric.svd(nda)
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref))
         allowscalar() do
-            sv = Array(s)
+            sv = Array(F.S)
             @test all(sv .>= 0)
             @test issorted(sv; rev=true)
         end
@@ -350,10 +365,9 @@ end
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_SVD_TYPES)
         n = 4
         A_ref = Matrix{T}(I, n, n)
-        nda = cuNumeric.NDArray(A_ref)
-        _, s, _ = cuNumeric.svd(nda)
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref))
         allowscalar() do
-            @test safe_compare(ones(T, n), s, atol(T), rtol(T))
+            @test safe_compare(ones(T, n), F.S, atol(T), rtol(T))
         end
     end
 end
@@ -365,10 +379,9 @@ end
         v1 = T.(collect(1:5))
         v2 = T.(collect(1:4))
         A_ref = v1 * v2'
-        nda = cuNumeric.NDArray(A_ref)
-        _, s, _ = cuNumeric.svd(nda)
+        F = LinearAlgebra.svd(cuNumeric.NDArray(A_ref))
         allowscalar() do
-            sv = Array(s)
+            sv = Array(F.S)
             @test sv[1] > atol(T)
             @test all(sv[2:end] .< sqrt(atol(T)) * 100)
         end
@@ -379,10 +392,10 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = T == Bool ? T[1 0; 0 1] : reshape(T.(collect(1:4)), 2, 2)
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" cuNumeric.svd(A)
+        @test_throws "Implicit promotion" LinearAlgebra.svd(A)
         allowpromotion() do
-            u, s, vh = cuNumeric.svd(A)
-            @test eltype(Array(u)) == Float64
+            F = LinearAlgebra.svd(A)
+            @test eltype(Array(F.U)) == Float64
         end
     end
 end
@@ -390,8 +403,7 @@ end
 @testset "qr reconstruction" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_QR_TYPES)
         A_ref = my_rand(T, 6, 4)
-        nda = cuNumeric.NDArray(A_ref)
-        q, r = cuNumeric.qr(nda)
+        q, r = LinearAlgebra.qr(cuNumeric.NDArray(A_ref))
         allowscalar() do
             Q = Array(q)
             R = Array(r)
@@ -406,8 +418,7 @@ end
 @testset "qr square matrix" begin
     @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_QR_TYPES)
         A_ref = my_rand(T, 5, 5)
-        nda = cuNumeric.NDArray(A_ref)
-        q, r = cuNumeric.qr(nda)
+        q, r = LinearAlgebra.qr(cuNumeric.NDArray(A_ref))
         allowscalar() do
             Q = Array(q)
             R = Array(r)
@@ -422,13 +433,228 @@ end
     @testset verbose=true for T in (Int32, Int64, Bool)
         vals = T == Bool ? T[1 0; 0 1] : reshape(T.(collect(1:4)), 2, 2)
         A = cuNumeric.NDArray(vals)
-        @test_throws "Implicit promotion" cuNumeric.qr(A)
+        @test_throws "Implicit promotion" LinearAlgebra.qr(A)
         allowpromotion() do
-            q, r = cuNumeric.qr(A)
+            q, r = LinearAlgebra.qr(A)
             allowscalar() do
                 @test eltype(Array(q)) == Float64
                 @test isapprox(
                     Float64.(vals), Array(q) * Array(r); atol=atol(Float64), rtol=rtol(Float64)
+                )
+            end
+        end
+    end
+end
+
+@testset "qr returns an NDArrayQR factorization" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_QR_TYPES)
+        A_ref = my_rand(T, 6, 4; L=real(T)(-1), R=real(T)(1))
+
+        F = LinearAlgebra.qr(cuNumeric.NDArray(A_ref))
+        @test F isa cuNumeric.NDArrayQR{T}
+        @test F isa LinearAlgebra.Factorization{T}
+        @test size(F) == (6, 4)
+        @test size(F, 1) == 6
+        @test size(F, 2) == 4
+        @test size(F, 3) == 1
+        @test sprint(show, MIME("text/plain"), F) isa String
+
+        allowscalar() do
+            @test isapprox(A_ref, Array(F.Q) * Array(F.R); atol=atol(T), rtol=rtol(T))
+        end
+    end
+end
+
+# Hermitian positive-definite, with a diagonal shift to keep it well conditioned.
+function spd_matrix(::Type{T}, n) where {T}
+    RT = real(T)
+    B = my_rand(T, n, n; L=RT(-1), R=RT(1))
+    return B * B' + T(n) * Matrix{T}(I, n, n)
+end
+
+@testset "cholesky reconstruction" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_CHOLESKY_TYPES)
+        n = 6
+        A_ref = spd_matrix(T, n)
+        F = LinearAlgebra.cholesky(cuNumeric.NDArray(A_ref))
+
+        @test F isa LinearAlgebra.Cholesky
+        @test F.uplo == 'L'
+
+        allowscalar() do
+            L = Array(F.factors)
+            @test size(L) == (n, n)
+            @test istril(L)  # `zeroout` clears the upper triangle in-task
+            @test isapprox(A_ref, L * L'; atol=atol(T), rtol=rtol(T))
+        end
+    end
+end
+
+@testset "cholesky of the identity" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_CHOLESKY_TYPES)
+        n = 4
+        A_ref = Matrix{T}(I, n, n)
+        F = LinearAlgebra.cholesky(cuNumeric.NDArray(A_ref))
+        allowscalar() do
+            @test safe_compare(A_ref, F.factors, atol(T), rtol(T))
+        end
+    end
+end
+
+@testset "cholesky factorization object" begin
+    n = 5
+    T = Float64
+    A_ref = spd_matrix(T, n)
+    F = LinearAlgebra.cholesky(cuNumeric.NDArray(A_ref))
+
+    L = F.L
+    @test L isa LowerTriangular
+    @test parent(L) === F.factors
+    @test size(F) == (n, n)
+
+    allowscalar() do
+        @test isapprox(A_ref, Array(parent(L)) * Array(parent(L))'; atol=atol(T), rtol=rtol(T))
+    end
+
+    # `F.U` (and hence destructuring as `L, U = F`) needs `copy(F.factors')`,
+    # which falls back to scalar indexing until `adjoint(::NDArray)` lands.
+    @test_throws "scalar-indexed" F.U
+end
+
+@testset "cholesky rejects bad shapes and types" begin
+    @test_throws ArgumentError LinearAlgebra.cholesky(cuNumeric.zeros(Float64, 3, 4))
+    @test_throws ArgumentError LinearAlgebra.cholesky(cuNumeric.zeros(ComplexF64, 0, 0))
+end
+
+# The POTRF task raises this itself. It only surfaces as a catchable error
+# because the launcher marks the task as throwing; without that Legate aborts
+# the process. Not a PosDefException: the pivot index is not reported.
+@testset "cholesky of a non-positive-definite matrix throws" begin
+    A = cuNumeric.NDArray(Float64[1.0 2.0; 2.0 1.0])
+    @test_throws "Matrix is not positive definite" begin
+        F = LinearAlgebra.cholesky(A)
+        allowscalar() do
+            sum(abs.(Array(F.factors)))
+        end
+    end
+end
+
+@testset "cholesky promotion" begin
+    @testset verbose=true for T in (Int32, Int64, Bool)
+        vals = T == Bool ? T[1 0; 0 1] : T[2 0; 0 2]
+        A = cuNumeric.NDArray(vals)
+        @test_throws "Implicit promotion" LinearAlgebra.cholesky(A)
+        allowpromotion() do
+            F = LinearAlgebra.cholesky(A)
+            allowscalar() do
+                L = Array(F.factors)
+                @test eltype(L) == Float64
+                @test isapprox(Float64.(vals), L * L'; atol=atol(Float64), rtol=rtol(Float64))
+            end
+        end
+    end
+end
+
+# Eigenvectors are only unique up to sign/phase, so compare the residual
+# `A*v - λ*v` rather than the vectors themselves.
+function eigen_residual(A_ref, values, vectors)
+    C = eltype(values)
+    return maximum(abs.(C.(A_ref) * vectors .- vectors * Diagonal(values)))
+end
+
+sort_spectrum(v) = sort(v; by=x -> (real(x), imag(x)))
+
+@testset "eigen residual" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_EIG_TYPES)
+        n = 5
+        A_ref = my_rand(T, n, n; L=real(T)(-1), R=real(T)(1))
+        F = LinearAlgebra.eigen(cuNumeric.NDArray(A_ref))
+
+        @test F isa LinearAlgebra.Eigen
+
+        allowscalar() do
+            values, vectors = Array(F.values), Array(F.vectors)
+            # geev always produces complex output, even for a real input matrix
+            @test eltype(values) == complex(T)
+            @test eltype(vectors) == complex(T)
+            @test size(values) == (n,)
+            @test size(vectors) == (n, n)
+            @test eigen_residual(A_ref, values, vectors) <= max(atol(T), rtol(T) * n)
+            @test isapprox(
+                sort_spectrum(values),
+                sort_spectrum(LinearAlgebra.eigvals(A_ref)),
+                atol=atol(T),
+                rtol=rtol(T),
+            )
+        end
+    end
+end
+
+@testset "eigen of a diagonal matrix" begin
+    @testset verbose=true for T in Base.uniontypes(cuNumeric.SUPPORTED_EIG_TYPES)
+        n = 4
+        A_ref = Matrix{T}(Diagonal(T.(1:n)))
+        values = LinearAlgebra.eigvals(cuNumeric.NDArray(A_ref))
+        allowscalar() do
+            @test isapprox(
+                sort_spectrum(Array(values)),
+                complex(T).(1:n),
+                atol=atol(T),
+                rtol=rtol(T),
+            )
+        end
+    end
+end
+
+@testset "eigen factorization object" begin
+    n = 5
+    T = Float64
+    A_ref = my_rand(T, n, n; L=-1.0, R=1.0)
+    F = LinearAlgebra.eigen(cuNumeric.NDArray(A_ref))
+
+    # an Eigen destructures as (values, vectors)
+    values, vectors = F
+    @test values === F.values
+    @test vectors === F.vectors
+
+    allowscalar() do
+        @test eigen_residual(A_ref, Array(values), Array(vectors)) <= rtol(T) * n
+    end
+end
+
+@testset "eigvals and eigvecs agree with eigen" begin
+    n = 4
+    T = Float64
+    A_ref = my_rand(T, n, n; L=-1.0, R=1.0)
+    nda = cuNumeric.NDArray(A_ref)
+
+    values = LinearAlgebra.eigvals(nda)
+    vectors = LinearAlgebra.eigvecs(nda)
+
+    allowscalar() do
+        @test eigen_residual(A_ref, Array(values), Array(vectors)) <= rtol(T) * n
+    end
+end
+
+@testset "eigen rejects bad shapes and types" begin
+    @test_throws ArgumentError LinearAlgebra.eigen(cuNumeric.zeros(Float64, 3, 4))
+    @test_throws ArgumentError LinearAlgebra.eigvals(cuNumeric.zeros(Float64, 0, 0))
+end
+
+@testset "eigen promotion" begin
+    @testset verbose=true for T in (Int32, Int64, Bool)
+        vals = T == Bool ? T[1 0; 0 1] : T[2 0; 0 3]
+        A = cuNumeric.NDArray(vals)
+        @test_throws "Implicit promotion" LinearAlgebra.eigen(A)
+        allowpromotion() do
+            F = LinearAlgebra.eigen(A)
+            allowscalar() do
+                @test eltype(Array(F.values)) == ComplexF64
+                @test isapprox(
+                    sort_spectrum(Array(F.values)),
+                    sort_spectrum(ComplexF64.(LinearAlgebra.eigvals(Float64.(vals)))),
+                    atol=atol(Float64),
+                    rtol=rtol(Float64),
                 )
             end
         end

--- a/test/util.jl
+++ b/test/util.jl
@@ -27,6 +27,10 @@ const DOMAIN_GENERATORS = Dict{Symbol,Function}(
     :positive => (T, N) -> (x=rand(T, N); T <: Signed ? abs.(max.(x, -typemax(T))) : x),
 )
 
+# The package only gates promotion when the target type is wider in bytes, so
+# Int64/UInt64 -> Float64 needs no `@allowpromotion` while Int32/Bool do.
+promotion_is_gated(::Type{FROM}, ::Type{TO}) where {FROM,TO} = sizeof(TO) > sizeof(FROM)
+
 rtol(::Type{Float16}) = 1e-2
 rtol(::Type{Float32}) = 1e-5
 rtol(::Type{Float64}) = 1e-12


### PR DESCRIPTION
## Summary

Adds `cholesky` and `eigen` to the linear algebra interface, wires the existing
`svd`/`qr` into Julia's `LinearAlgebra` API, and splits batched (3D) operations
into their own `batched_*` namespace.

## New user-facing API

All 2D operations are now `LinearAlgebra` overloads returning standard
factorization objects, so they compose with the rest of the Julia ecosystem:

| Call | Returns | Status |
|---|---|---|
| `cholesky(A)` | `LinearAlgebra.Cholesky` | new |
| `eigen(A)` | `LinearAlgebra.Eigen` | new |
| `eigvals(A)` | complex `NDArray` | new |
| `eigvecs(A)` | complex `NDArray` | new |
| `A \ b` | `NDArray` | new |
| `svd(A; full=false)` | `LinearAlgebra.SVD` | rewired |
| `qr(A)` | `NDArrayQR` | rewired |

Batched operations take a stack of shape `(b, m, m)` — batch dimension first.
They have no `LinearAlgebra` counterpart, so they keep the prefix and return
plain tuples/arrays rather than factorization objects:

- `cuNumeric.batched_solve(A, B)`
- `cuNumeric.batched_cholesky(A)`
- `cuNumeric.batched_eigen(A) -> (values, vectors)`
- `cuNumeric.batched_eigvals(A)`

New exported type `NDArrayQR <: LinearAlgebra.Factorization`. The backend hands
back materialized `Q` and `R` rather than the packed Householder representation
Base uses, so this can't be a `QRCompactWY`. It destructures as `(Q, R)` and
exposes `F.Q` / `F.R`.

Also adds the `SUPPORTED_CHOLESKY_TYPES` and `SUPPORTED_EIG_TYPES` unions.


## Behavior worth knowing

- `eigen`/`eigvals` **always return complex** values and vectors, even for real
  input with real eigenvalues. This follows the underlying LAPACK `geev` path
  and differs from Base, which returns real factors in that case.
- `cholesky` reads only the lower triangle and does *not* check that the input
  is Hermitian. A non-positive-definite input raises `ErrorException` rather
  than `PosDefException`, so the `check` keyword is not supported.
- Destructuring an `SVD` yields `(U, S, V)`, where `V` is a lazy `Adjoint`
  wrapper that falls back to scalar indexing until `adjoint(::NDArray)` exists.
  Prefer `F.Vt`.


