### PR TITLE
Implement == and != as 0-d Bool reductions.

### DIFF
--- a/lib/cunumeric_jl_wrapper/include/ndarray_c_api.h
+++ b/lib/cunumeric_jl_wrapper/include/ndarray_c_api.h
@@ -96,6 +96,9 @@ uint64_t nda_nbytes(CN_NDArray* arr);
 
 void nda_binary_op(CN_NDArray* out, CuPyNumericBinaryOpCode op_code,
                    const CN_NDArray* rhs1, const CN_NDArray* rhs2);
+void nda_binary_reduction(CN_NDArray* out, CuPyNumericBinaryOpCode op_code,
+                          const CN_NDArray* rhs1, const CN_NDArray* rhs2);
+CN_NDArray* nda_array_equal(const CN_NDArray* rhs1, const CN_NDArray* rhs2);
 void nda_unary_op(CN_NDArray* out, CuPyNumericUnaryOpCode op_code,
                   CN_NDArray* input);
 void nda_unary_reduction(CN_NDArray* out, CuPyNumericUnaryRedCode op_code,

--- a/src/ndarray/binary.jl
+++ b/src/ndarray/binary.jl
@@ -299,18 +299,6 @@ end
     return result
 end
 
-# function Base.:(==)(lhs::NDArray{A}, rhs::NDArray{B}) where {A,B}
-#     error("Not implemented yet")
-#     #! REPLACE WITH ARRAY_EQUAL ONCE THAT IS WRAPPED
-#     #! or explicit call to nda_binary_reduction
-# end
-
-# function Base.:(!=)(lhs::NDArray{A}, rhs::NDArray{B}) where {A,B}
-#     error("Not implemented yet")
-#     #! REPLACE WITH ARRAY_EQUAL ONCE THAT IS WRAPPED
-#     #! or explicit call to nda_binary_reduction
-# end
-
 # Specializations for 2 and -1 in unary.jl
 @inline function __broadcast(
     f::typeof(Base.literal_pow), out::NDArray, _, input::NDArray{T}, power::NDArray{T}

--- a/src/ndarray/detail/ndarray.jl
+++ b/src/ndarray/detail/ndarray.jl
@@ -370,6 +370,17 @@ function nda_binary_op!(out::NDArray, op_code::BinaryOpCode, rhs1::NDArray, rhs2
     return out
 end
 
+function nda_binary_reduction!(
+    out::NDArray, op_code::BinaryOpCode, rhs1::NDArray, rhs2::NDArray
+)
+    @task_scope _scope_op("binary_red", op_code) begin
+        ccall((:nda_binary_reduction, libnda),
+            Cvoid, (NDArray_t, BinaryOpCode, NDArray_t, NDArray_t),
+            out.ptr, op_code, rhs1.ptr, rhs2.ptr)
+    end
+    return out
+end
+
 function nda_unary_op!(out::NDArray, op_code::UnaryOpCode, input::NDArray)
     @task_scope _scope_op("unary", op_code) begin
         ccall((:nda_unary_op, libnda),

--- a/src/ndarray/ndarray.jl
+++ b/src/ndarray/ndarray.jl
@@ -839,16 +839,12 @@ unwrap(x::NDArray) = only(x)
 
 @doc"""
     ==(arr1::NDArray, arr2::NDArray)
+    !=(arr1::NDArray, arr2::NDArray)
 
-Check if two NDArrays are equal element-wise.
-
-Returns `true` if both arrays have the same shape and all corresponding elements are equal.
-Currently supports arrays up to 3 dimensions. For higher dimensions, returns `false` with a warning.
-
-!!! warning
-
-    This function uses scalar indexing and should not be used in production code. This is meant for testing.
-
+Element-wise equality reduced to a 0-d `NDArray{Bool}` (not a Julia `Bool`).
+Same shape and values yields true; mismatched shape or rank yields false.
+Mixed dtypes follow Julia `==` (promote, then compare). Use `unwrap` or `A[]`
+(with `allowscalar`) for a host value. Broadcast `.==` / `.!=` stay elementwise.
 
 # Examples
 ```@repl
@@ -859,12 +855,47 @@ c = cuNumeric.zeros(2, 2)
 a == c
 ```
 """
-function Base.:(==)(arr1::NDArray{T,N}, arr2::NDArray{T,N}) where {T,N}
-    return nda_array_equal(arr1, arr2) #DOESNT RETURN SCALAR
+function Base.:(==)(a::NDArray, b::NDArray)
+    size(a) == size(b) || return NDArray(false)
+    return _array_equal_impl(a, b)
 end
 
-function Base.:(!=)(arr1::NDArray{T,N}, arr2::NDArray{T,N}) where {T,N}
-    return !(arr1 == arr2)
+function Base.:(!=)(a::NDArray, b::NDArray)
+    return !(a == b)
+end
+
+function _array_equal_impl(a::NDArray{T}, b::NDArray{T}) where {T}
+    out = cuNumeric.zeros(Bool)
+    return nda_binary_reduction!(out, cuNumeric.EQUAL, a, b)
+end
+
+function _array_equal_impl(a::NDArray{A}, b::NDArray{B}) where {A,B}
+    T = promote_type(A, B)
+    return _array_equal_promoted(a, b, T)
+end
+
+function _array_equal_promoted(a::NDArray{T}, b::NDArray{T}, ::Type{T}) where {T}
+    return _array_equal_impl(a, b)
+end
+function _array_equal_promoted(a::NDArray, b::NDArray{T}, ::Type{T}) where {T}
+    p1 = unchecked_promote_arr(a, T)
+    result = _array_equal_impl(p1, b)
+    destroy!(p1)
+    return result
+end
+function _array_equal_promoted(a::NDArray{T}, b::NDArray, ::Type{T}) where {T}
+    p2 = unchecked_promote_arr(b, T)
+    result = _array_equal_impl(a, p2)
+    destroy!(p2)
+    return result
+end
+function _array_equal_promoted(a::NDArray, b::NDArray, ::Type{T}) where {T}
+    p1 = unchecked_promote_arr(a, T)
+    p2 = unchecked_promote_arr(b, T)
+    result = _array_equal_impl(p1, p2)
+    destroy!(p1)
+    destroy!(p2)
+    return result
 end
 
 @doc"""

--- a/test/array/binary/float.jl
+++ b/test/array/binary/float.jl
@@ -25,3 +25,4 @@ run_binary_ops_tests(
         Base.uniontypes(cuNumeric.SUPPORTED_ARRAY_TYPES),
     ),
 )
+run_array_equal_tests()

--- a/test/array/binary/tests.jl
+++ b/test/array/binary/tests.jl
@@ -178,9 +178,13 @@ function run_binary_ops_tests(types)
             end
 
             allowscalar() do
-                @test unwrap(arr_cn == arr_cn)
+                eq = arr_cn == arr_cn
+                neq = arr_cn != arr_cn2
+                @test ndims(eq) == 0
+                @test ndims(neq) == 0
+                @test unwrap(eq)
                 @test !unwrap(arr_cn == arr_cn2)
-                @test unwrap(arr_cn != arr_cn2)
+                @test unwrap(neq)
                 @test !unwrap(arr_cn != arr_cn)
                 @test unwrap(all(arr_cn .== arr_cn))
             end
@@ -194,5 +198,36 @@ function run_binary_copyto_tests()
         b = cuNumeric.ones(2, 2)
         copyto!(a, b)
         @test is_same(a, b)
+    end
+end
+
+function run_array_equal_tests()
+    @testset "0-d == / !=" begin
+        a32 = Float32[1, 2, 3]
+        a64 = Float64[1, 2, 3]
+        n32 = @allowscalar NDArray(a32)
+        n64 = @allowscalar NDArray(a64)
+
+        allowscalar() do
+            @test ndims(n32 == n64) == 0
+            @test unwrap(n32 == n64) == (a32 == a64)
+            @test unwrap(n32 != n64) == (a32 != a64)
+
+            b64 = Float64[1, 2, 4]
+            m64 = NDArray(b64)
+            @test unwrap(n32 == m64) == (a32 == b64)
+            @test unwrap(n32 != m64) == (a32 != b64)
+        end
+
+        same = cuNumeric.ones(2, 2)
+        other_shape = cuNumeric.ones(3, 3)
+        other_rank = cuNumeric.ones(4)
+        allowscalar() do
+            @test ndims(same == other_shape) == 0
+            @test !unwrap(same == other_shape)
+            @test unwrap(same != other_shape)
+            @test !unwrap(same == other_rank)
+            @test unwrap(same != other_rank)
+        end
     end
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -56,9 +56,9 @@ function reduction_atol(::Type{T}, n, scale=1) where {T}
     return max(atol(T) * n, n * eps(FT) * abs(scale))
 end
 
-is_same(arr1::NDArray, arr2::NDArray) = @allowscalar (arr1 == arr2)[1]
-is_same(arr1::NDArray, arr2::Array) = @allowscalar (arr1 == arr2)[1]
-is_same(arr1::Array, arr2::NDArray) = @allowscalar (arr1 == arr2)[1]
+is_same(arr1::NDArray, arr2::NDArray) = unwrap(arr1 == arr2)
+is_same(arr1::NDArray, arr2::Array) = @allowscalar (arr1 == arr2)
+is_same(arr1::Array, arr2::NDArray) = @allowscalar (arr1 == arr2)
 is_same(arr1::Array, arr2::Array) = (arr1 == arr2)
 
 function my_rand(::Type{F}, dims...; L=F(-1000), R=F(1000)) where {F<:AbstractFloat}


### PR DESCRIPTION
ARRAY_EQUAL task returned a 1D store before. This implements a version that returns a 0D store so that `==` and `!=` return `NDArray{Bool, 0}`.

