### PR TITLE
Return 0D NDArray from TensorOperations API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We implement a package extension for [TensorOperations.jl](https://github.com/Qu
 using TensorOperations
 using cuNumeric
 
-α = randn() # Must be Julia scalar, not NDArray currently
+α = randn() # prefer a Julia Number when you already have one
 A = cuNumeric.randn(5, 5, 5, 5, 5, 5)
 B = cuNumeric.randn(5, 5, 5)
 C = cuNumeric.randn(5, 5, 5)

--- a/docs/src/api_tensor.md
+++ b/docs/src/api_tensor.md
@@ -18,7 +18,7 @@ of this page.
 using cuNumeric
 using TensorOperations
 
-α = randn() # Julia scalar, not a 0D NDArray
+α = randn() # prefer a Julia Number when you already have one
 A = cuNumeric.randn(5, 5, 5, 5, 5, 5)
 B = cuNumeric.randn(5, 5, 5)
 C = cuNumeric.randn(5, 5, 5)
@@ -32,14 +32,11 @@ end
 
 ## Scalars
 
-`@tensor` does **not** use the same 0D-`NDArray` convention as the rest of cuNumeric. In the future we will break the TensorOperatoins API so that scalars are 0D Arrays instead.
+Prefer a Julia `Number` for scale factors when possible (i.e., `2.0f0`, `randn()`, …). This allows TensorOperations.jl to perform optimizatoins for special values like zero and one.
 
-```@raw html
-<ol>
-<li><strong>Scale factors must be Julia scalars.</strong> Coefficients such as <code>α</code> in <code>α * C[i, j]</code> must be a Julia <code>Number</code>. A 0D <code>NDArray</code> (for example the result of <code>sum</code>) is not accepted.</li>
-<li><strong>A fully contracted result is a Julia scalar.</strong> When every index is contracted, <code>@tensor</code> returns a host <code>Number</code>, not a 0D <code>NDArray</code>. TensorOperations gets that value with <code>tensorscalar</code>, which indexes the rank-zero array and therefore needs <code>@allowscalar</code>.</li>
-</ol>
-```
+A 0D `NDArray` is also accepted as a scale — for example `sum(C)`, or a
+fully contracted `@tensor` result. If you intend to use these results in down-stream tensor contractions keep those on device. `unwrap` copies the value to the host and **blocks the Legate runtime**, so only unwrap
+when you truly need a Julia `Number` (i.e. printing of host-side if-else).
 
 ```julia
 A = cuNumeric.rand(Float64, 64, 32)
@@ -47,19 +44,12 @@ B = cuNumeric.rand(Float64, 32, 16)
 
 @tensor opt=true C[i, j] := A[i, k] * B[k, j]   # NDArray
 
-α = 2.0                                         # OK
-# α = sum(C)                                    # 0D NDArray, not a scale factor
-@tensor D[i, j] := α * C[i, j]
+α = 2.0
+@tensor D[i, j] := α * C[i, j]          # Julia Number, no sync
 
-@allowscalar @tensor s = conj(C[i, j]) * C[i, j]  # Julia Number, blocks
-```
-
-Full contractions also force a host synchronization, which stalls the Legate
-runtime. If you can keep a 0D `NDArray` instead, use an ordinary reduction:
-
-```julia
-s = sum(conj(C) .* C)   # NDArray{T,0}, stays asynchronous
-x = unwrap(s)           # host Number, only when you need it
+@tensor s = conj(C[i, j]) * C[i, j]    # 0D NDArray, stays asynchronous
+@tensor E[i, j] := s * C[i, j]         # reuse 0D as a scale, still no unwrap
+x = unwrap(s)                          # host Number; blocks
 ```
 
 ## Low-level `contract` / `contract!`
@@ -88,9 +78,10 @@ contract!(CC, "ijl", AA, "ijk", BB, "ikl")
 tensordot(AA, BB, ([3], [2]))               # same contraction, axes form
 ```
 
-`α` and `β` implement `C = β*C + α*(A ⋆ B)` in Julia. The C++ kernel always
-writes the unscaled product; `β ≠ 0` uses a temporary. Duplicate labels inside
-one array are not allowed — use `cuNumeric.diagonal` first.
+`α` and `β` implement `C = β*C + α*(A ⋆ B)` in Julia. Prefer a Julia `Number`;
+a 0-d `NDArray` is also accepted. The C++ kernel always writes the unscaled
+product; `β ≠ 0` uses a temporary. Duplicate labels inside one array are not
+allowed — use `cuNumeric.diagonal` first.
 
 This path is multi-GPU via Legate tiling (per-tile cuTENSOR or TBLIS), not
 cuTensorMp. Integer and `Bool` inputs promote to `Float64` like other linalg.

--- a/docs/src/examples/tensor_network.md
+++ b/docs/src/examples/tensor_network.md
@@ -13,8 +13,8 @@ H = S^x_1 S^x_2 + S^y_1 S^y_2 + S^z_1 S^z_2.
 
 The examples below apply it to an MPS-like state with tensors ``A^{(1)}``,
 ``A^{(2)}`` and boundary environments ``L``, ``R``. The first contractions keep
-open bond indices and stay `NDArray`s. The second contracts every index to a
-host scalar.
+open bond indices and stay `NDArray`s. The second contracts every index; the
+ratio stays on device until `unwrap` for printing.
 
 ```julia
 # found in examples/tensor_network.jl
@@ -23,7 +23,7 @@ using LinearAlgebra
 using Random
 using TensorOperations
 
-Random.seed!(1234)
+Random.seed!(1234) # for Random.randn, cuNumeric expects seed via default_rng
 
 physical_dim = 2
 bond_dim = 16
@@ -44,7 +44,7 @@ R = NDArray(randn(ComplexF64, bond_dim, bond_dim))
 
 These contractions have free indices ``a, s_1, s_2, b``, so the results are
 `NDArray`s. TensorOperations lowers the network to pairwise contractions and
-releases the intermediate `NDArray`s. Nothing here indexes a single element.
+releases the intermediate `NDArray`s.
 
 ```julia
 @tensor ψ[a, s1, s2, b] :=
@@ -57,21 +57,15 @@ println("Hψ is a ", typeof(Hψ), " of size ", size(Hψ))
 
 ## Expectation value
 
-A fully contracted `@tensor` assignment is a Julia scalar, not a 0D `NDArray`.
-That path needs `@allowscalar`. See [Scalars](../api_tensor.md#Scalars) for
-the full rules, including that scale factors must be Julia `Number`s.
+A fully contracted `@tensor` assignment is a 0D `NDArray`, like `sum`.
+Prefer to keep it that way and do device arithmetic (`./`) until you
+need a host `Number`. `unwrap` (here, only to print) **blocks**. See
+[Scalars](../api_tensor.md#Scalars).
 
 ```julia
-energy, norm² = @allowscalar begin
-    @tensor begin
-        e = conj(ψ[a, s1, s2, b]) * Hψ[a, s1, s2, b]
-        n = conj(ψ[a, s1, s2, b]) * ψ[a, s1, s2, b]
-    end
-    e, n
-end
+@tensor energy = conj(ψ[a, s1, s2, b]) * Hψ[a, s1, s2, b]
+@tensor norm² = conj(ψ[a, s1, s2, b]) * ψ[a, s1, s2, b]
 
-println("two-site energy = ", real(energy / norm²))
+println("two-site energy = ", real(unwrap(energy ./ norm²)))
 ```
-
-The extension also supports output-index permutations, traces, conjugation, and
-accumulation into an existing tensor. See [Tensor Contractions](../api_tensor.md).
+See [Tensor Contractions](../api_tensor.md) documentation for more details.

--- a/docs/src/perf/patterns_to_avoid.md
+++ b/docs/src/perf/patterns_to_avoid.md
@@ -4,7 +4,10 @@
 
 Accessing elements of an NDArray one at a time (e.g., `arr[5]`) is slow and should be avoided. Indexing like this requires data to be transferred between device and host and maybe even communicated across nodes. Scalar indexing will emit an error which can be opted out of with `@allowscalar` or `allowscalar() do ... end`. Several functions in the existing API invoke scalar indexing and are intended for testing (e.g., the `==` operator).
 
-Scalar indexing can also appear through the [TensorOperations.jl](https://github.com/QuantumKitHub/TensorOperations.jl) extension when contractions reduce to a scalar. See [Scalars](../api_tensor.md#Scalars). In the future, we may break their API and return 0D NDArrays instead, to avoid blocking the runtime. Today, this can usually be avoided by using other reductions like `sum`, which do return 0D NDArrays, inplace of the einsum notation.
+`unwrap` (and `A[]`) pulls a host `Number` out of a 0D `NDArray` and
+**blocks the runtime**. Prefer a Julia `Number` when you already have one,
+and leave reductions / fully contracted `@tensor` results as 0D arrays
+until you actually need the host value. See [Scalars](../api_tensor.md#Scalars).
 
 ## Implicit promotion
 

--- a/examples/tensor_network.jl
+++ b/examples/tensor_network.jl
@@ -1,8 +1,8 @@
-#= Contract a two-site tensor network, then optionally pull a host scalar.
+#= Contract a two-site tensor network, then print a host scalar.
 
 The first contractions build an MPS-like two-site state and apply a Heisenberg
-operator. Those results stay on device as NDArrays. Fully contracting to
-⟨ψ|H|ψ⟩ / ⟨ψ|ψ⟩ goes through tensorscalar and therefore needs @allowscalar.
+operator. Those results stay on device as NDArrays. The fully contracted
+⟨ψ|H|ψ⟩ / ⟨ψ|ψ⟩ ratio is computed on device; unwrap only to print (it blocks).
 =#
 
 using cuNumeric
@@ -34,16 +34,9 @@ R = NDArray(randn(ComplexF64, BOND_DIM, BOND_DIM))
 println("ψ is a ", typeof(ψ), " of size ", size(ψ))
 println("Hψ is a ", typeof(Hψ), " of size ", size(Hψ))
 
-# Fully contracted @tensor results go through tensorscalar, which indexes the
-# rank-zero NDArray. That is scalar indexing and needs @allowscalar.
-# This code could be replicated by calling `sum` to get a 0D-NDArray results
-# that does NOT block the runtime.
-energy, norm² = @allowscalar begin
-    @tensor begin
-        e = conj(ψ[a, s1, s2, b]) * Hψ[a, s1, s2, b]
-        n = conj(ψ[a, s1, s2, b]) * ψ[a, s1, s2, b]
-    end
-    e, n
-end
+# Fully contracted @tensor results are 0D NDArrays. Keep them on device
+# until a host Number is required; unwrap blocks.
+@tensor energy = conj(ψ[a, s1, s2, b]) * Hψ[a, s1, s2, b]
+@tensor norm² = conj(ψ[a, s1, s2, b]) * ψ[a, s1, s2, b]
 
-println("two-site energy = ", real(energy / norm²))
+println("two-site energy = ", real(unwrap(energy ./ norm²)))

--- a/ext/cuNumericTensorOperationsExt.jl
+++ b/ext/cuNumericTensorOperationsExt.jl
@@ -23,6 +23,8 @@ using TensorOperations
 
 const CN = cuNumeric
 const TO = TensorOperations
+const One = TO.One
+const Zero = TO.Zero
 
 struct CuNumericBackend <: TO.AbstractBackend end
 
@@ -70,31 +72,102 @@ function TO.tensorfree!(C::CN.NDArray, allocator=TO.DefaultAllocator())
     return nothing
 end
 
-function _accumulate!(C::CN.NDArray{T}, A::CN.NDArray, α, β) where {T}
-    α′ = convert(T, α)
-    if iszero(β)
-        C .= α′ .* A
-    else
-        β′ = convert(T, β)
-        C .= β′ .* C .+ α′ .* A
+# ------------------------------------------------------------------------------------------
+# Scale factors: One/Zero dispatch, Number wraps to 0D and re-dispatches
+# ------------------------------------------------------------------------------------------
+
+function _require_0d_scale(x::CN.NDArray)
+    ndims(x) == 0 || throw(
+        DimensionMismatch("tensor scale factor must be a Julia Number or a 0-d NDArray")
+    )
+    return x
+end
+
+_as_scale(x::One, ::Type) = x
+_as_scale(x::Zero, ::Type) = x
+function _as_scale(x::CN.NDArray, ::Type{T}) where {T}
+    _require_0d_scale(x)
+    return _convert_eltype(x, T)
+end
+function _as_scale(x::Number, ::Type{T}) where {T}
+    isone(x) && return One()
+    iszero(x) && return Zero()
+    return CN.NDArray(convert(T, x))
+end
+
+function _free_scale!(orig, scaled)
+    if scaled isa CN.NDArray && !(orig isa CN.NDArray && orig === scaled)
+        CN.destroy!(scaled)
     end
+    return nothing
+end
+
+_accumulate!(C::CN.NDArray, A::CN.NDArray, ::One, ::Zero) = (C.=A; C)
+_accumulate!(C::CN.NDArray, A::CN.NDArray, α::CN.NDArray, ::Zero) = (C.=α .* A; C)
+_accumulate!(C::CN.NDArray, A::CN.NDArray, ::One, ::One) = (C.=C .+ A; C)
+_accumulate!(C::CN.NDArray, A::CN.NDArray, α::CN.NDArray, ::One) = (C.=C .+ α .* A; C)
+_accumulate!(C::CN.NDArray, A::CN.NDArray, ::One, β::CN.NDArray) = (C.=β .* C .+ A; C)
+function _accumulate!(C::CN.NDArray, A::CN.NDArray, α::CN.NDArray, β::CN.NDArray)
+    C .= β .* C .+ α .* A
     return C
+end
+# α = 0: product does not contribute. Strong-zero for β = 0 does not read C.
+_accumulate!(C::CN.NDArray, ::CN.NDArray, ::Zero, ::Zero) = (C.=zero(eltype(C)); C)
+_accumulate!(C::CN.NDArray, ::CN.NDArray, ::Zero, ::One) = C
+_accumulate!(C::CN.NDArray, ::CN.NDArray, ::Zero, β::CN.NDArray) = (C.=β .* C; C)
+
+function _accumulate!(C::CN.NDArray{T}, A::CN.NDArray, α::Number, β::Number) where {T}
+    α′ = _as_scale(α, T)
+    β′ = _as_scale(β, T)
+    try
+        return _accumulate!(C, A, α′, β′)
+    finally
+        _free_scale!(α, α′)
+        _free_scale!(β, β′)
+    end
+end
+
+function _accumulate!(C::CN.NDArray{T}, A::CN.NDArray, α::CN.NDArray, β::Number) where {T}
+    α′ = _as_scale(α, T)
+    β′ = _as_scale(β, T)
+    try
+        return _accumulate!(C, A, α′, β′)
+    finally
+        _free_scale!(α, α′)
+        _free_scale!(β, β′)
+    end
+end
+
+function _accumulate!(C::CN.NDArray{T}, A::CN.NDArray, α::Number, β::CN.NDArray) where {T}
+    α′ = _as_scale(α, T)
+    β′ = _as_scale(β, T)
+    try
+        return _accumulate!(C, A, α′, β′)
+    finally
+        _free_scale!(α, α′)
+        _free_scale!(β, β′)
+    end
 end
 
 function _convert_eltype(A::CN.NDArray, ::Type{T}) where {T}
     return eltype(A) === T ? A : CN.as_type(A, T)
 end
 
-function TO.tensoradd!(
-    C::CN.NDArray,
-    A::CN.NDArray,
-    pA::TO.Index2Tuple,
-    conjA::Bool,
-    α::Number,
-    β::Number,
-    ::CuNumericBackend,
-    allocator=TO.DefaultAllocator(),
-)
+function _ensure_backend(op, backend, C, select_args...)
+    if backend isa TO.DefaultBackend
+        return TO.select_backend(op, C, select_args...)
+    elseif backend isa CuNumericBackend
+        return backend
+    else
+        throw(ArgumentError("Unknown backend $backend for $op and NDArray"))
+    end
+end
+
+# ------------------------------------------------------------------------------------------
+# tensoradd!
+# ------------------------------------------------------------------------------------------
+
+function _tensoradd_impl!(C::CN.NDArray, A::CN.NDArray, pA, conjA, α, β)
     TO.argcheck_tensoradd(C, A, pA)
     TO.dimcheck_tensoradd(C, A, pA)
     if C.ptr === A.ptr && !TO.istrivialpermutation(pA)
@@ -115,6 +188,105 @@ function TO.tensoradd!(
     opA !== A && CN.destroy!(opA)
     return C
 end
+
+function TO.tensoradd!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::Number,
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    return _tensoradd_impl!(C, A, pA, conjA, α, β)
+end
+
+function TO.tensoradd!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    α::CN.NDArray,
+    β::Union{Number,CN.NDArray},
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    _require_0d_scale(α)
+    β isa CN.NDArray && _require_0d_scale(β)
+    return _tensoradd_impl!(C, A, pA, conjA, α, β)
+end
+
+function TO.tensoradd!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    _require_0d_scale(β)
+    return _tensoradd_impl!(C, A, pA, conjA, α, β)
+end
+
+function TO.tensoradd!(
+    C::CN.NDArray, A::CN.NDArray, pA::TO.Index2Tuple, conjA::Bool, α::CN.NDArray, β
+)
+    return TO.tensoradd!(C, A, pA, conjA, α, β, TO.DefaultBackend())
+end
+function TO.tensoradd!(
+    C::CN.NDArray, A::CN.NDArray, pA::TO.Index2Tuple, conjA::Bool, α::Number, β::CN.NDArray
+)
+    return TO.tensoradd!(C, A, pA, conjA, α, β, TO.DefaultBackend())
+end
+function TO.tensoradd!(
+    C::CN.NDArray, A::CN.NDArray, pA::TO.Index2Tuple, conjA::Bool, α::CN.NDArray, β, backend
+)
+    return TO.tensoradd!(C, A, pA, conjA, α, β, backend, TO.DefaultAllocator())
+end
+function TO.tensoradd!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+    backend,
+)
+    return TO.tensoradd!(C, A, pA, conjA, α, β, backend, TO.DefaultAllocator())
+end
+function TO.tensoradd!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    α::CN.NDArray,
+    β,
+    backend,
+    allocator,
+)
+    b = _ensure_backend(TO.tensoradd!, backend, C, A)
+    return TO.tensoradd!(C, A, pA, conjA, α, β, b, allocator)
+end
+function TO.tensoradd!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+    backend,
+    allocator,
+)
+    b = _ensure_backend(TO.tensoradd!, backend, C, A)
+    return TO.tensoradd!(C, A, pA, conjA, α, β, b, allocator)
+end
+
+# ------------------------------------------------------------------------------------------
+# tensortrace!
+# ------------------------------------------------------------------------------------------
 
 function _trace_pairs(A::CN.NDArray, q::TO.Index2Tuple)
     current = A
@@ -139,17 +311,7 @@ function _trace_pairs(A::CN.NDArray, q::TO.Index2Tuple)
     return current, current_owned, labels
 end
 
-function TO.tensortrace!(
-    C::CN.NDArray,
-    A::CN.NDArray,
-    p::TO.Index2Tuple,
-    q::TO.Index2Tuple,
-    conjA::Bool,
-    α::Number,
-    β::Number,
-    ::CuNumericBackend,
-    allocator=TO.DefaultAllocator(),
-)
+function _tensortrace_impl!(C::CN.NDArray, A::CN.NDArray, p, q, conjA, α, β)
     TO.argcheck_tensortrace(C, A, p, q)
     TO.dimcheck_tensortrace(C, A, p, q)
     C.ptr === A.ptr && throw(ArgumentError("output tensor must not alias input tensor"))
@@ -170,6 +332,130 @@ function TO.tensortrace!(
     opA !== A && CN.destroy!(opA)
     return C
 end
+
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::Number,
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    return _tensortrace_impl!(C, A, p, q, conjA, α, β)
+end
+
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::CN.NDArray,
+    β::Union{Number,CN.NDArray},
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    _require_0d_scale(α)
+    β isa CN.NDArray && _require_0d_scale(β)
+    return _tensortrace_impl!(C, A, p, q, conjA, α, β)
+end
+
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    _require_0d_scale(β)
+    return _tensortrace_impl!(C, A, p, q, conjA, α, β)
+end
+
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::CN.NDArray,
+    β,
+)
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, TO.DefaultBackend())
+end
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+)
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, TO.DefaultBackend())
+end
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::CN.NDArray,
+    β,
+    backend,
+)
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, backend, TO.DefaultAllocator())
+end
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+    backend,
+)
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, backend, TO.DefaultAllocator())
+end
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::CN.NDArray,
+    β,
+    backend,
+    allocator,
+)
+    b = _ensure_backend(TO.tensortrace!, backend, C, A)
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, b, allocator)
+end
+function TO.tensortrace!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    p::TO.Index2Tuple,
+    q::TO.Index2Tuple,
+    conjA::Bool,
+    α::Number,
+    β::CN.NDArray,
+    backend,
+    allocator,
+)
+    b = _ensure_backend(TO.tensortrace!, backend, C, A)
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, b, allocator)
+end
+
+# ------------------------------------------------------------------------------------------
+# tensorcontract!
+# ------------------------------------------------------------------------------------------
 
 function _contract_modes(
     A::CN.NDArray,
@@ -198,19 +484,8 @@ function _contract_modes(
     return Cmodes, Amodes, Bmodes
 end
 
-function TO.tensorcontract!(
-    C::CN.NDArray,
-    A::CN.NDArray,
-    pA::TO.Index2Tuple,
-    conjA::Bool,
-    B::CN.NDArray,
-    pB::TO.Index2Tuple,
-    conjB::Bool,
-    pAB::TO.Index2Tuple,
-    α::Number,
-    β::Number,
-    ::CuNumericBackend,
-    allocator=TO.DefaultAllocator(),
+function _tensorcontract_impl!(
+    C::CN.NDArray, A::CN.NDArray, pA, conjA, B::CN.NDArray, pB, conjB, pAB, α, β
 )
     TO.argcheck_tensorcontract(C, A, pA, B, pB, pAB)
     TO.dimcheck_tensorcontract(C, A, pA, B, pB, pAB)
@@ -230,9 +505,164 @@ function TO.tensorcontract!(
     return C
 end
 
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::Number,
+    β::Number,
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    return _tensorcontract_impl!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)
+end
+
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::CN.NDArray,
+    β::Union{Number,CN.NDArray},
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    _require_0d_scale(α)
+    β isa CN.NDArray && _require_0d_scale(β)
+    return _tensorcontract_impl!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)
+end
+
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::Number,
+    β::CN.NDArray,
+    ::CuNumericBackend,
+    allocator=TO.DefaultAllocator(),
+)
+    _require_0d_scale(β)
+    return _tensorcontract_impl!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)
+end
+
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::CN.NDArray,
+    β,
+)
+    return TO.tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, TO.DefaultBackend()
+    )
+end
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::Number,
+    β::CN.NDArray,
+)
+    return TO.tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, TO.DefaultBackend()
+    )
+end
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::CN.NDArray,
+    β,
+    backend,
+)
+    return TO.tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend, TO.DefaultAllocator()
+    )
+end
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::Number,
+    β::CN.NDArray,
+    backend,
+)
+    return TO.tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend, TO.DefaultAllocator()
+    )
+end
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::CN.NDArray,
+    β,
+    backend,
+    allocator,
+)
+    b = _ensure_backend(TO.tensorcontract!, backend, C, A, B)
+    return TO.tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, b, allocator)
+end
+function TO.tensorcontract!(
+    C::CN.NDArray,
+    A::CN.NDArray,
+    pA::TO.Index2Tuple,
+    conjA::Bool,
+    B::CN.NDArray,
+    pB::TO.Index2Tuple,
+    conjB::Bool,
+    pAB::TO.Index2Tuple,
+    α::Number,
+    β::CN.NDArray,
+    backend,
+    allocator,
+)
+    b = _ensure_backend(TO.tensorcontract!, backend, C, A, B)
+    return TO.tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, b, allocator)
+end
+
 function TO.tensorscalar(C::CN.NDArray)
     ndims(C) == 0 || throw(DimensionMismatch("tensorscalar requires a rank-zero tensor"))
-    return C[]
+    return copy(C)
 end
 
 end

--- a/src/ndarray/contract.jl
+++ b/src/ndarray/contract.jl
@@ -179,6 +179,8 @@ end
 
 In-place pairwise tensor contraction `C = β * C + α * (A ⋆ B)`.
 
+`α` and `β` may be a Julia `Number` or a 0-d `NDArray`.
+
 `Amodes`, `Bmodes`, and `Cmodes` are mode labels for `A`, `B`, and `C`: an
 ASCII `AbstractString`, a tuple/vector of `Char`, or a vector of integers
 (`1` maps to `'a'`). Each label appears twice (a contracted or free index) or
@@ -210,7 +212,7 @@ function contract!(
     Ap = checked_promote_arr(contract!, A, T)
     Bp = checked_promote_arr(contract!, B, T)
     try
-        return _contract_same_type!(C, Cmodes, Ap, Amodes, Bp, Bmodes, convert(T, α), convert(T, β))
+        return _contract_same_type!(C, Cmodes, Ap, Amodes, Bp, Bmodes, α, β)
     finally
         Ap !== A && destroy!(Ap)
         Bp !== B && destroy!(Bp)
@@ -226,15 +228,15 @@ function contract!(C::NDArray, Cmodes, A::NDArray, Amodes, B::NDArray, Bmodes; �
     return throw(ArgumentError("array type $bad is unsupported in contract!"))
 end
 
-function _contract_same_type!(
-    C::NDArray{T},
-    Cmodes,
-    A::NDArray{T},
-    Amodes,
-    B::NDArray{T},
-    Bmodes,
-    α::T,
-    β::T,
+function _require_0d_scale(x::NDArray)
+    ndims(x) == 0 || throw(
+        ArgumentError("contract! scale factor must be a Number or a 0-d NDArray")
+    )
+    return x
+end
+
+function _contract_prepare(
+    C::NDArray{T}, Cmodes, A::NDArray{T}, Amodes, B::NDArray{T}, Bmodes
 ) where {T}
     (C.ptr === A.ptr || C.ptr === B.ptr) && throw(
         ArgumentError("contract! output must not alias either input")
@@ -252,21 +254,117 @@ function _contract_same_type!(
         )
     end
     extent_keys, extent_vals = _extent_arrays(extents)
+    return Cm, Am, Bm, extent_keys, extent_vals
+end
 
+function _contract_same_type!(
+    C::NDArray{T},
+    Cmodes,
+    A::NDArray{T},
+    Amodes,
+    B::NDArray{T},
+    Bmodes,
+    α::Number,
+    β::Number,
+) where {T}
+    Cm, Am, Bm, extent_keys, extent_vals = _contract_prepare(C, Cmodes, A, Amodes, B, Bmodes)
     if isone(α) && iszero(β)
         _nda_contract!(C, Cm, A, Am, B, Bm, extent_keys, extent_vals)
         return C
     end
+    αT = convert(T, α)
     if iszero(β)
         _nda_contract!(C, Cm, A, Am, B, Bm, extent_keys, extent_vals)
-        C .= α .* C
+        C .= αT .* C
         return C
     end
+    βT = convert(T, β)
     tmp = similar(C)
     _nda_contract!(tmp, Cm, A, Am, B, Bm, extent_keys, extent_vals)
-    C .= β .* C .+ α .* tmp
+    C .= βT .* C .+ αT .* tmp
     destroy!(tmp)
     return C
+end
+
+function _contract_same_type!(
+    C::NDArray{T},
+    Cmodes,
+    A::NDArray{T},
+    Amodes,
+    B::NDArray{T},
+    Bmodes,
+    α::NDArray,
+    β::Number,
+) where {T}
+    _require_0d_scale(α)
+    Cm, Am, Bm, extent_keys, extent_vals = _contract_prepare(C, Cmodes, A, Amodes, B, Bmodes)
+    α′ = eltype(α) === T ? α : as_type(α, T)
+    try
+        if iszero(β)
+            _nda_contract!(C, Cm, A, Am, B, Bm, extent_keys, extent_vals)
+            C .= α′ .* C
+            return C
+        end
+        tmp = similar(C)
+        _nda_contract!(tmp, Cm, A, Am, B, Bm, extent_keys, extent_vals)
+        if isone(β)
+            C .= C .+ α′ .* tmp
+        else
+            βa = NDArray(convert(T, β))
+            C .= βa .* C .+ α′ .* tmp
+            destroy!(βa)
+        end
+        destroy!(tmp)
+        return C
+    finally
+        α′ !== α && destroy!(α′)
+    end
+end
+
+function _contract_same_type!(
+    C::NDArray{T},
+    Cmodes,
+    A::NDArray{T},
+    Amodes,
+    B::NDArray{T},
+    Bmodes,
+    α::Number,
+    β::NDArray,
+) where {T}
+    _require_0d_scale(β)
+    αa = NDArray(convert(T, α))
+    try
+        return _contract_same_type!(C, Cmodes, A, Amodes, B, Bmodes, αa, β)
+    finally
+        destroy!(αa)
+    end
+end
+
+function _contract_same_type!(
+    C::NDArray{T},
+    Cmodes,
+    A::NDArray{T},
+    Amodes,
+    B::NDArray{T},
+    Bmodes,
+    α::NDArray,
+    β::NDArray,
+) where {T}
+    _require_0d_scale(α)
+    _require_0d_scale(β)
+    Cm, Am, Bm, extent_keys, extent_vals = _contract_prepare(C, Cmodes, A, Amodes, B, Bmodes)
+    α′ = eltype(α) === T ? α : as_type(α, T)
+    β′ = eltype(β) === T ? β : as_type(β, T)
+    try
+        tmp = similar(C)
+        _nda_contract!(tmp, Cm, A, Am, B, Bm, extent_keys, extent_vals)
+        C .= β′ .* C .+ α′ .* tmp
+        destroy!(tmp)
+        return C
+    finally
+        α′ !== α && destroy!(α′)
+        β′ !== β && destroy!(β′)
+    end
 end
 
 """

--- a/test/array/contract.jl
+++ b/test/array/contract.jl
@@ -216,6 +216,16 @@ end
         _host_contract_compare(
             β3 * seed_ji + α2 * permutedims(prod), out_ji, T; n=nk, scale=α2 * scale
         )
+
+        α0 = NDArray(α2)
+        out = cuNumeric.zeros(T, 4, 5)
+        contract!(out, "ij", nda, "ik", ndb, "kj"; α=α0, β=0)
+        _host_contract_compare(α2 * prod, out, T; n=nk, scale=α2 * scale)
+
+        β0 = NDArray(β3)
+        out = NDArray(copy(seed))
+        contract!(out, "ij", nda, "ik", ndb, "kj"; α=α0, β=β0)
+        _host_contract_compare(β3 * seed + α2 * prod, out, T; n=nk, scale=α2 * scale)
     end
 end
 

--- a/test/array/tensoroperations.jl
+++ b/test/array/tensoroperations.jl
@@ -164,15 +164,16 @@ using TensorOperations: TensorOperations as TO
 
         matrix = reshape(ComplexF64.(1:9) .+ im .* ComplexF64.(9:-1:1), 3, 3)
         M = NDArray(matrix)
-        @test_throws ErrorException (@tensor t = M[i, i])
-        scalar_trace = @allowscalar @tensor(t = M[i, i])
-        @test scalar_trace isa ComplexF64
-        @test scalar_trace == sum(matrix[i, i] for i in axes(matrix, 1))
+        scalar_trace = @tensor(t = M[i, i])
+        @test scalar_trace isa NDArray
+        @test ndims(scalar_trace) == 0
+        @test only(Array(scalar_trace)) == sum(matrix[i, i] for i in axes(matrix, 1))
 
         conjugated_trace = TO.tensortrace(M, ((), ()), ((1,), (2,)), true)
-        @test_throws ErrorException TO.tensorscalar(conjugated_trace)
-        @test (@allowscalar TO.tensorscalar(conjugated_trace)) ==
-            sum(conj(matrix[i, i]) for i in axes(matrix, 1))
+        ts = TO.tensorscalar(conjugated_trace)
+        @test ts isa NDArray
+        @test ndims(ts) == 0
+        @test only(Array(ts)) == sum(conj(matrix[i, i]) for i in axes(matrix, 1))
         TO.tensorfree!(conjugated_trace)
     end
 
@@ -206,9 +207,31 @@ using TensorOperations: TensorOperations as TO
         vhost = ComplexF64.(5:8) .- im .* ComplexF64.(1:4)
         u = NDArray(uhost)
         v = NDArray(vhost)
-        scalar_product = @allowscalar @tensor(s = u[k] * v[k])
-        @test scalar_product isa ComplexF64
-        @test scalar_product ≈ sum(uhost .* vhost)
+        scalar_product = @tensor(s = u[k] * v[k])
+        @test scalar_product isa NDArray
+        @test ndims(scalar_product) == 0
+        @test only(Array(scalar_product)) ≈ sum(uhost .* vhost)
+    end
+
+    @testset "0D NDArray scale factors" begin
+        hostC = reshape(collect(Float64, 1:6), 2, 3)
+        C = NDArray(hostC)
+        α = sum(C)
+        @test α isa NDArray
+        @test ndims(α) == 0
+
+        @tensor scaled[i, j] := α * C[i, j]
+        @test Array(scaled) ≈ only(Array(α)) .* hostC
+
+        @tensor s = C[i, j] * C[i, j]
+        @test s isa NDArray
+        @test ndims(s) == 0
+        @tensor scaled2[i, j] := s * C[i, j]
+        @test Array(scaled2) ≈ only(Array(s)) .* hostC
+
+        dest = NDArray(fill(2.0, 2, 3))
+        @tensor dest[i, j] += α * C[i, j]
+        @test Array(dest) ≈ fill(2.0, 2, 3) .+ only(Array(α)) .* hostC
     end
 
     @testset "temporary destruction" begin


### PR DESCRIPTION
Modify behavior around scalars so that fully contracted tensors are 0D NDArrays instead of automatically unwrapping.

Fixes #189 